### PR TITLE
Add ephemeral container to a running pod

### DIFF
--- a/examples/add-ephemeral.js
+++ b/examples/add-ephemeral.js
@@ -12,6 +12,7 @@ export default function () {
   const containerName = "ephemeral"
   const containerImage = "busybox" 
   const containerCommand = ["sh", "-c", "sleep 300"]
+  const containerCapabilities = ["NET_ADMIN","NET_RAW"]
 
   kubernetes.pods.create({
     namespace: namespace,
@@ -28,6 +29,7 @@ export default function () {
       name: containerName,
       image: containerImage,
       command: containerCommand,
+      capabilities: containerCapabilities,
     }   
   )
   sleep(1)

--- a/examples/add-ephemeral.js
+++ b/examples/add-ephemeral.js
@@ -1,0 +1,41 @@
+import { sleep } from 'k6';
+import { Kubernetes } from 'k6/x/kubernetes';
+
+export default function () {
+  const kubernetes = new Kubernetes({
+    // config_path: "/path/to/kube/config", ~/.kube/config by default
+  })
+  const namespace = "default"
+  const podName = "new-pod"
+  const image = "busybox"
+  const command = ["sh",  "-c", "sleep 300"]
+  const containerName = "ephemeral"
+  const containerImage = "busybox" 
+  const containerCommand = ["sh", "-c", "sleep 300"]
+
+  kubernetes.pods.create({
+    namespace: namespace,
+    name: podName,
+    image: image,
+    command: command
+  })
+  sleep(1)
+
+  kubernetes.pods.addEphemeralContainer(
+    podName,
+    namespace,
+    {
+      name: containerName,
+      image: containerImage,
+      command: containerCommand,
+    }   
+  )
+  sleep(1)
+
+  let pod = kubernetes.pods.get(podName, namespace)
+  if (pod.spec.ephemeral_containers[0].name == containerName) {
+    console.log(containerName + " container successfully created")
+  } else {
+    throw containername + " container not created"
+  }
+}

--- a/examples/create-pod.js
+++ b/examples/create-pod.js
@@ -1,0 +1,32 @@
+
+import { sleep } from 'k6';
+import { Kubernetes } from 'k6/x/kubernetes';
+
+function getPodNames(nameSpace, kubernetes) {
+  return kubernetes.pods.list(nameSpace).map(function(pod){
+    return pod.name
+  })
+}
+
+export default function () {
+  const kubernetes = new Kubernetes({
+  })
+  const namespace = "default"
+  const podName = "new-pod"
+  const image = "busybox"
+  const command = ["sh",  "-c", "sleep 300"]
+
+  kubernetes.pods.create({
+    namespace: namespace,
+    name: podName,
+    image: image,
+    command: command
+  })
+  sleep(1)
+  const podsList = getPodNames(namespace, kubernetes)
+  if(podsList.indexOf(podName) != -1) {
+    console.log(podName + " pod has been created successfully")
+  } else {
+    throw podName + " pod was not created"
+  }
+}

--- a/go.sum
+++ b/go.sum
@@ -623,6 +623,7 @@ k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.8.0 h1:Q3gmuM9hKEjefWFFYF0Mat+YyFJvsUyYuwyNNJ5C9Ts=
 k8s.io/klog/v2 v2.8.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6/go.mod h1:UuqjUnNftUyPE5H64/qeyjQoUZhGpeFDVdxjTeEVN2o=
+k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 h1:vEx13qjvaZ4yfObSSXW7BrMc/KQBBT/Jyee8XtLf4x0=
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
 k8s.io/utils v0.0.0-20200729134348-d5654de09c73 h1:uJmqzgNWG7XyClnU/mLPBWwfKKF1K8Hf8whTseBgJcg=
 k8s.io/utils v0.0.0-20200729134348-d5654de09c73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=

--- a/pkg/pods/pods.go
+++ b/pkg/pods/pods.go
@@ -21,9 +21,10 @@ func New(client *kubernetes.Clientset, metaOptions metav1.ListOptions, ctx conte
 }
 
 type ContainerOptions struct {
-	Name    string
-	Image   string
-	Command []string
+	Name         string
+	Image        string
+	Command      []string
+	Capabilities []string
 }
 
 type Pods struct {
@@ -141,12 +142,21 @@ func (obj *Pods) AddEphemeralContainer(name, namespace string, options Container
 }
 
 func generateEphemeralContainer(o ContainerOptions) (*k8sTypes.EphemeralContainer, error) {
+	var capabilities []k8sTypes.Capability
+	for _, capability := range o.Capabilities {
+		capabilities = append(capabilities, k8sTypes.Capability(capability))
+	}
 
 	return &k8sTypes.EphemeralContainer{
 		EphemeralContainerCommon: k8sTypes.EphemeralContainerCommon{
 			Name:    o.Name,
 			Image:   o.Image,
 			Command: o.Command,
+			SecurityContext: &k8sTypes.SecurityContext{
+				Capabilities: &k8sTypes.Capabilities{
+					Add: capabilities,
+				},
+			},
 		},
 	}, nil
 }

--- a/pkg/pods/pods.go
+++ b/pkg/pods/pods.go
@@ -23,6 +23,14 @@ type Pods struct {
 	ctx         context.Context
 }
 
+type PodOptions struct {
+	Namespace     string
+	Name          string
+	Image         string
+	Command       []string
+	RestartPolicy k8sTypes.RestartPolicy
+}
+
 func (obj *Pods) List(namespace string) ([]k8sTypes.Pod, error) {
 	pods, err := obj.client.CoreV1().Pods(namespace).List(obj.ctx, obj.metaOptions)
 	if err != nil {
@@ -59,4 +67,34 @@ func (obj *Pods) IsTerminating(name, namespace string) (bool, error) {
 		return false, err
 	}
 	return (pod.ObjectMeta.DeletionTimestamp != nil), nil
+}
+
+func (obj *Pods) Create(options PodOptions) (k8sTypes.Pod, error) {
+	container := k8sTypes.Container{
+		Name:    options.Name,
+		Image:   options.Image,
+		Command: options.Command,
+	}
+
+	containers := []k8sTypes.Container{
+		container,
+	}
+
+	var restartPolicy k8sTypes.RestartPolicy = "Never"
+
+	if options.RestartPolicy != "" {
+		restartPolicy = options.RestartPolicy
+	}
+
+	newPod := k8sTypes.Pod{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: options.Name},
+		Spec: k8sTypes.PodSpec{
+			Containers:    containers,
+			RestartPolicy: restartPolicy,
+		},
+	}
+
+	pod, err := obj.client.CoreV1().Pods(options.Namespace).Create(obj.ctx, &newPod, metav1.CreateOptions{})
+	return *pod, err
 }

--- a/pkg/pods/pods.go
+++ b/pkg/pods/pods.go
@@ -20,11 +20,12 @@ func New(client *kubernetes.Clientset, metaOptions metav1.ListOptions, ctx conte
 	}
 }
 
+// ContainerOptions describes a container to be started in a pod
 type ContainerOptions struct {
-	Name         string
-	Image        string
-	Command      []string
-	Capabilities []string
+	Name         string	// name of the container
+	Image        string	// image to be attached
+	Command      []string	// command to be executed by the container
+	Capabilities []string	// capabilities to be added to the container's security context
 }
 
 type Pods struct {
@@ -33,12 +34,13 @@ type Pods struct {
 	ctx         context.Context
 }
 
+// PodOptions describe a Pod to be executed
 type PodOptions struct {
-	Namespace     string
-	Name          string
-	Image         string
-	Command       []string
-	RestartPolicy k8sTypes.RestartPolicy
+	Namespace     string			// namespace where the pod will be executed
+	Name          string			// name of the pod
+	Image         string			// image to be executed by the pod's container
+	Command       []string			// command to be executed by the pod's container and its arguments
+	RestartPolicy k8sTypes.RestartPolicy	// policy for restarting containers in the pod. One of One of Always, OnFailure, Never
 }
 
 func (obj *Pods) List(namespace string) ([]k8sTypes.Pod, error) {
@@ -79,6 +81,7 @@ func (obj *Pods) IsTerminating(name, namespace string) (bool, error) {
 	return (pod.ObjectMeta.DeletionTimestamp != nil), nil
 }
 
+// Create runs a pod specified by the options
 func (obj *Pods) Create(options PodOptions) (k8sTypes.Pod, error) {
 	container := k8sTypes.Container{
 		Name:    options.Name,
@@ -109,6 +112,8 @@ func (obj *Pods) Create(options PodOptions) (k8sTypes.Pod, error) {
 	return *pod, err
 }
 
+// AddEphemeralContainer adds an ephemeral container to a running pod. The Pod is identified by name and namespace.
+// The container is described by options
 func (obj *Pods) AddEphemeralContainer(name, namespace string, options ContainerOptions) error {
 	pod, err := obj.Get(name, namespace)
 	if err != nil {


### PR DESCRIPTION
Add function to Pods for creating an ephemeral container in a running pod.
Also added a function for creating a pod to facilitate testing.

Note: tested with K8s cluster 1.23.x. Previous versions may not work or may need enabling ephemeral containers feature gate

closes #30 