### PR TITLE
Add Exec command to Pods

### DIFF
--- a/examples/exec-command.js
+++ b/examples/exec-command.js
@@ -1,0 +1,42 @@
+
+import { sleep } from 'k6';
+import { Kubernetes } from 'k6/x/kubernetes';
+
+export default function () {
+  const kubernetes = new Kubernetes({
+  })
+  const namespace = "default"
+  const podName = "new-pod"
+  const image = "busybox"
+  const command = ["sh",  "-c", "sleep 300"]
+
+  kubernetes.pods.create({
+    namespace: namespace,
+    name: podName,
+    image: image,
+    command: command
+  })
+  sleep(3)
+
+  const newPod = kubernetes.pods.list(namespace).find(function(pod) { return pod.name == podName}) 
+  if (!newPod) {
+    throw podName + " pod was not created"
+  }
+
+  const container = newPod.spec.containers[0].name
+  const result = kubernetes.pods.exec({
+    namespace: namespace,
+    pod: podName,
+    container: container.name,
+    command: ["echo", "'hello xk6'"],
+    stadin:  []
+  })
+
+  const stdout = String.fromCharCode(...result.stdout)
+
+  if (stdout.includes("xk6")) {
+    console.log("command executed")
+  } else {
+    throw "command not executed correctly"
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/nxadm/tail v1.4.4 // indirect
@@ -48,6 +49,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/klog/v2 v2.8.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 // indirect
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.0 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,7 @@ github.com/dop251/goja v0.0.0-20220124171016-cfb079cdc7b4/go.mod h1:R9ET47fwRVRP
 github.com/dop251/goja v0.0.0-20220405120441-9037c2b61cbf h1:Yt+4K30SdjOkRoRRm3vYNQgR+/ZIy0RmeUDZo7Y8zeQ=
 github.com/dop251/goja v0.0.0-20220405120441-9037c2b61cbf/go.mod h1:R9ET47fwRVRPZnOGvHxxhuZcbrMCuiqOz3Rlrh4KSnk=
 github.com/dop251/goja_nodejs v0.0.0-20210225215109-d91c329300e7/go.mod h1:hn7BA7c8pLvoGndExHudxTDKZ84Pyvv+90pbBjbTz0Y=
+github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -263,6 +264,7 @@ github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS4
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -124,7 +124,7 @@ func (mi *ModuleInstance) newClient(c goja.ConstructorCall) *goja.Object {
 	obj.ConfigMaps = configmaps.New(obj.client, obj.metaOptions, obj.ctx)
 	obj.Ingresses = ingresses.New(obj.client, obj.metaOptions, obj.ctx)
 	obj.Deployments = deployments.New(obj.client, obj.metaOptions, obj.ctx)
-	obj.Pods = pods.New(obj.client, obj.metaOptions, obj.ctx)
+	obj.Pods = pods.New(obj.client, config, obj.metaOptions, obj.ctx)
 	obj.Namespaces = namespaces.New(obj.client, obj.metaOptions, obj.ctx)
 	obj.Nodes = nodes.New(obj.client, obj.metaOptions, obj.ctx)
 	obj.Jobs = jobs.New(obj.client, obj.metaOptions, obj.ctx)


### PR DESCRIPTION
Add function for executing a command in an existing pod and return the output (stdin and strerr) in a similar way than executing a non interactive command using `kubectl exec`

Note: for implementing this functionality it is necessary to access the k8s client configuration. As the client library does not allow to retrieve it from the client instance, it was necessary to add the config to the Pod structure.

Closes https://github.com/grafana/xk6-kubernetes/issues/35