### PR TITLE
Add wait option to Pod Create

### DIFF
--- a/examples/create-pod-wait.js
+++ b/examples/create-pod-wait.js
@@ -1,0 +1,22 @@
+
+import { sleep } from 'k6';
+import { Kubernetes } from 'k6/x/kubernetes';
+
+export default function () {
+  const kubernetes = new Kubernetes({
+  })
+  const namespace = "default"
+  const podName = "new-pod"
+  const image = "busybox"
+  const command = ["sh",  "-c", "/bin/false"]
+
+  kubernetes.pods.create({
+    namespace: namespace,
+    name: podName,
+    image: image,
+    command: command,
+    wait: "10s"
+  })
+  
+  console.log(podName + " pod is running")
+}

--- a/examples/create-pod-wait.js
+++ b/examples/create-pod-wait.js
@@ -10,13 +10,16 @@ export default function () {
   const image = "busybox"
   const command = ["sh",  "-c", "/bin/false"]
 
+try {  
   kubernetes.pods.create({
     namespace: namespace,
     name: podName,
     image: image,
     command: command,
-    wait: "10s"
+    wait: "5s"
   })
-  
-  console.log(podName + " pod is running")
+  console.log(podName + " has been created")
+} catch (err) {
+  console.log("error creating pod " + podName + ": " + err)
+}
 }

--- a/examples/wait-pod.js
+++ b/examples/wait-pod.js
@@ -1,0 +1,32 @@
+
+import { sleep } from 'k6';
+import { Kubernetes } from 'k6/x/kubernetes';
+
+export default function () {
+  const kubernetes = new Kubernetes({
+  })
+  const namespace = "default"
+  const podName = "new-pod"
+  const image = "busybox"
+  const command = ["sh",  "-c", "sleep 5"]
+
+  kubernetes.pods.create({
+    namespace: namespace,
+    name: podName,
+    image: image,
+    command: command
+  })
+  
+ 
+  const options = {
+    namespace: namespace,
+    name: podName,
+    status: "Succeeded",
+    timeout: "10s"
+  }
+  if (kubernetes.pods.wait(options)) {
+    console.log(podName + " pod completed successfully")
+  } else {
+    throw podName + " is not completed"
+  }
+}

--- a/internal/testutils/kube_resources.go
+++ b/internal/testutils/kube_resources.go
@@ -226,7 +226,17 @@ func NewPod(name string, namespace string) *coreV1.Pod {
 			},
 			EphemeralContainers: nil,
 		},
+		Status: coreV1.PodStatus{
+			Phase: coreV1.PodRunning,
+		},
 	}
+}
+
+// NewPodWithStatus is a helper for building Pods with a given Status
+func NewPodWithStatus(name string, namespace string, phase string) *coreV1.Pod {
+	pod := NewPod(name, namespace)
+	pod.Status.Phase = coreV1.PodPhase(phase)
+	return pod
 }
 
 // NewSecret is a helper to build a new Secret instance

--- a/pkg/pods/pods.go
+++ b/pkg/pods/pods.go
@@ -176,7 +176,7 @@ type WaitOptions struct {
 // Wait for the Pod to be in a given status up to given timeout and returns a boolean indicating if the staus was reached. If the pod is Failed returns error.
 func (obj *Pods) Wait(options WaitOptions) (bool, error) {
 	if options.Status != Running && options.Status != Succeeded {
-		return false, errors.New("Wait condition must be 'Running' or 'Succeeded'")
+		return false, errors.New("wait condition must be 'Running' or 'Succeeded'")
 	}
 	timeout, err := time.ParseDuration(options.Timeout)
 	if err != nil {

--- a/pkg/pods/pods.go
+++ b/pkg/pods/pods.go
@@ -5,15 +5,25 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"time"
 
 	k8sTypes "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+)
+
+// ValidPod status 
+const (
+      Running string = "Running"
+      Succeeded string = "Succeeded"
 )
 
 func New(client kubernetes.Interface, config *rest.Config, metaOptions metav1.ListOptions, ctx context.Context) *Pods {
@@ -134,6 +144,62 @@ func (obj *Pods) Create(options PodOptions) (k8sTypes.Pod, error) {
 		return k8sTypes.Pod{}, err
 	}
 	return *pod, nil
+}
+
+// Options for waiting for a Pod status
+type WaitOptions struct {
+	Name string		// Pod name
+	Namespace string	// Namespace where the pod is running
+	Status string           // Wait until pod reaches the specified status. Must be one of "Running" or "Succeeded".
+	Timeout string		// Timeout for waiting condition to be true
+}
+
+// Wait for the Pod to be in a given status up to given timeout and returns a boolean indicating if the staus was reached. If the pod is Failed returns error.
+func (obj *Pods) Wait(options WaitOptions) (bool, error) {
+	if options.Status != Running && options.Status != Succeeded {
+		return false, errors.New("Wait condition must be 'Running' or 'Succeeded'")
+	}
+	timeout, err := time.ParseDuration(options.Timeout)
+	if err != nil {
+		return false, err
+	}
+	selector := fields.Set{
+		"metadata.name": options.Name,
+	}.AsSelector()
+	watcher, err := obj.client.CoreV1().Pods(options.Namespace).Watch(
+		obj.ctx,
+		metav1.ListOptions{
+			FieldSelector: selector.String(),
+                },
+	)
+        if err != nil {
+		return false, err
+        }
+	defer watcher.Stop()
+
+	for {
+		select {
+		case <-time.After(timeout):
+			return false, nil
+		case event := <-watcher.ResultChan():
+			if event.Type == watch.Error {
+				return false, fmt.Errorf("error watching for pod: %v", event.Object)
+			}
+			if event.Type == watch.Modified {
+				pod, isPod := event.Object.(*k8sTypes.Pod)
+				if !isPod {
+					return false, errors.New("received unknown object while watching for pods")
+				}
+				if pod.Status.Phase == k8sTypes.PodFailed {
+					return false, errors.New("Pod has failed")
+				}
+				if string(pod.Status.Phase) ==  options.Status {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
 }
 
 // Exec executes a non-interactive command described in options and returns the stdout and stderr outputs

--- a/pkg/pods/pods_test.go
+++ b/pkg/pods/pods_test.go
@@ -4,9 +4,12 @@ import (
 	"github.com/grafana/xk6-kubernetes/internal/testutils"
 	k8sTypes "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stest "k8s.io/client-go/testing"
 	"strings"
 	"testing"
+	"time"
 )
 
 var (
@@ -42,6 +45,90 @@ func TestPods_Create(t *testing.T) {
 	if len(pods) != 2 {
 		t.Errorf("expecting 2 pods in namespace, listing returned %v", len(pods))
 		return
+	}
+}
+
+func TestPods_Wait(t *testing.T) {
+	t.Parallel()
+	type TestCase struct {
+		test           string
+		name           string
+		namespace      string
+		status         string
+		delay          time.Duration
+		expectedStatus string
+		expectError    bool
+		expectedResult bool
+		timeout        string
+	}
+
+	testCases := []TestCase{
+		{
+			test:           "wait pod running",
+			name:           "pod-running",
+			namespace:      testNamespace,
+			status:         "Running",
+			delay:          1 * time.Second,
+			expectedStatus: "Running",
+			expectError:    false,
+			expectedResult: true,
+			timeout:        "5s",
+		},
+		{
+			test:           "timeout waiting pod running",
+			name:           "pod-running",
+			namespace:      testNamespace,
+			status:         "Running",
+			delay:          10 * time.Second,
+			expectedStatus: "Running",
+			expectError:    false,
+			expectedResult: false,
+			timeout:        "5s",
+		},
+		{
+			test:           "wait failed pod",
+			name:           "pod-running",
+			namespace:      testNamespace,
+			status:         "Failed",
+			delay:          1 * time.Second,
+			expectedStatus: "Running",
+			expectError:    true,
+			expectedResult: false,
+			timeout:        "5s",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.test, func(t *testing.T) {
+			// TODO Figure out the rest.Config
+			client := fake.NewSimpleClientset()
+			watcher := watch.NewFake()
+			client.PrependWatchReactor("pods", k8stest.DefaultWatchReactor(watcher, nil))
+			fixture := New(client, nil, metav1.ListOptions{}, nil)
+			go func(tc TestCase) {
+				time.Sleep(tc.delay)
+				watcher.Modify(testutils.NewPodWithStatus(tc.name, tc.namespace, tc.status))
+			}(tc)
+
+			result, err := fixture.Wait(WaitOptions{
+				Name:      tc.name,
+				Namespace: tc.namespace,
+				Status:    tc.expectedStatus,
+				Timeout:   tc.timeout,
+			})
+
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if tc.expectError && err == nil {
+				t.Errorf("Expected an error but none returned")
+				return
+			}
+			if result != tc.expectedResult {
+				t.Errorf("expected result %t but %t returned", tc.expectedResult, result)
+				return
+			}
+		})
 	}
 }
 

--- a/pkg/pods/pods_test.go
+++ b/pkg/pods/pods_test.go
@@ -101,7 +101,7 @@ func TestPods_Create(t *testing.T) {
 				return
 			}
 			if tc.expectError && err == nil {
-				t.Errorf("Expected an error but none returned")
+				t.Error("expected an error but none returned")
 				return
 			}
 			// error expected and returned, it is ok
@@ -110,7 +110,7 @@ func TestPods_Create(t *testing.T) {
 			}
 			// error is not expected and none returned, result must be valid
 			if result.Name != tc.name || result.Namespace != tc.namespace {
-				t.Errorf("incorrect instance was returned")
+				t.Error("incorrect instance was returned")
 				return
 			}
 			// FIXME: The fake client does not update the pod object in response to update
@@ -196,7 +196,7 @@ func TestPods_Wait(t *testing.T) {
 				return
 			}
 			if tc.expectError && err == nil {
-				t.Errorf("Expected an error but none returned")
+				t.Error("expected an error but none returned")
 				return
 			}
 			if result != tc.expectedResult {


### PR DESCRIPTION
Add option for waiting until the Pod is running to pod Create. if the pod is not running after a given timeout, an error is returned.

Closes #43 