### PR TITLE
Check job completion

### DIFF
--- a/examples/create-job-wait.js
+++ b/examples/create-job-wait.js
@@ -1,0 +1,29 @@
+
+import { sleep } from 'k6';
+import { Kubernetes } from 'k6/x/kubernetes';
+
+function getJobNames(nameSpace, kubernetes) {
+  return kubernetes.jobs.list(nameSpace).map(function(job){
+    return job.name
+  })
+}
+
+export default function () {
+  const kubernetes = new Kubernetes({
+    // config_path: "/path/to/kube/config", ~/.kube/config by default
+  })
+  const namespace = "default"
+  const jobName = "new-job"
+  const image = "perl"
+  const command = ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+
+  kubernetes.jobs.create({
+    namespace: namespace,
+    name: jobName,
+    image: image,
+    command: command,
+    wait: "30s"
+  })
+  console.log(jobName + " job completed")  
+}
+

--- a/examples/wait-job.js
+++ b/examples/wait-job.js
@@ -1,0 +1,34 @@
+
+import { sleep } from 'k6';
+import { Kubernetes } from 'k6/x/kubernetes';
+
+function getJobNames(nameSpace, kubernetes) {
+  return kubernetes.jobs.list(nameSpace).map(function(job){
+    return job.name
+  })
+}
+
+export default function () {
+  const kubernetes = new Kubernetes({
+    // config_path: "/path/to/kube/config", ~/.kube/config by default
+  })
+  const namespace = "default"
+  const jobName = "new-job"
+  const image = "perl"
+  const command = ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+
+  kubernetes.jobs.create({
+    namespace: namespace,
+    name: jobName,
+    image: image,
+    command: command
+  })
+
+  const completed = kubernetes.jobs.wait({
+    namespace: namespace,
+    name: jobName,
+    timeout: "30s"
+  })
+  const jobStatus = completed? "completed": "not completed"
+  console.log(jobName + " " + jobStatus)
+}

--- a/internal/testutils/kube_resources.go
+++ b/internal/testutils/kube_resources.go
@@ -113,7 +113,22 @@ func NewJob(name string, namespace string) *batchv1.Job {
 			BackoffLimit: nil,
 			Template:     coreV1.PodTemplateSpec{},
 		},
+		Status: batchv1.JobStatus{
+			Conditions: []batchv1.JobCondition{},
+		},
 	}
+}
+
+// NewJobWithStatus creates a job with a given condition
+func NewJobWithStatus(name string, namespace string, status string) *batchv1.Job {
+	job := NewJob(name, namespace)
+	job.Status.Conditions = []batchv1.JobCondition{
+		{
+			Type:   batchv1.JobConditionType(status),
+			Status: coreV1.ConditionTrue,
+		},
+	}
+	return job
 }
 
 // NewNamespace is a helper to build a new Namespace instance

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -120,33 +120,108 @@ spec:
 
 func TestJobs_Create(t *testing.T) {
 	t.Parallel()
-	fixture := New(fake.NewSimpleClientset(
-		testutils.NewJob("existing", testNamespace),
-	), metav1.ListOptions{}, nil)
+	type TestCase struct {
+               test        string
+               name        string
+               namespace   string
+               status      string
+               delay       time.Duration
+               expectError bool
+               wait        string
+        }
 
-	options := JobOptions{
-		Name:          testName,
-		Namespace:     testNamespace,
-		NodeName:      "node-1",
-		Image:         "perl",
-		Command:       []string{"perl", "-Mbignum=bpi", "-wle", "print bpi(2000)"},
-		RestartPolicy: k8sTypes.RestartPolicyNever,
-	}
-	result, err := fixture.Create(options)
+        testCases := []TestCase{
+               {
+                       test:        "create job not waiting",
+                       name:        "test-job",
+                       namespace:   testNamespace,
+                       status:      "Complete",
+                       delay:       1 * time.Second,
+                       expectError: false,
+                       wait:        "",
+               },
+               {
+                       test:        "create failed job not waiting",
+                       name:        "test-job",
+                       namespace:   testNamespace,
+                       status:      "Failed",
+                       delay:       1 * time.Second,
+                       expectError: false,
+                       wait:        "",
+               }, {
+                       test:        "wait for job to complete",
+                       name:        "test-job",
+                       namespace:   testNamespace,
+                       status:      "Complete",
+                       delay:       1 * time.Second,
+                       expectError: false,
+                       wait:        "2s",
+               },
+               {
+                       test:        "timeout waiting job complete",
+                       name:        "test-job",
+                       namespace:   testNamespace,
+                       status:      "Complete",
+                       delay:       10 * time.Second,
+                       expectError: true,
+                       wait:        "2s",
+               },
+               {
+                       test:        "wait failed job",
+                       name:        "pod-running",
+                       namespace:   testNamespace,
+                       status:      "Failed",
+                       delay:       1 * time.Second,
+                       expectError: true,
+                       wait:        "2s",
+               },
+       }
+       for _, tc := range testCases {
+               t.Run(tc.test, func(t *testing.T) {
+                       // TODO Figure out the rest.Config
+                       client := fake.NewSimpleClientset()
+                       watcher := watch.NewFake()
+                       client.PrependWatchReactor("jobs", k8stest.DefaultWatchReactor(watcher, nil))
+                       fixture := New(client, metav1.ListOptions{}, nil)
+                       go func(tc TestCase) {
+                               time.Sleep(tc.delay)
+                               watcher.Modify(testutils.NewJobWithStatus(tc.name, tc.namespace, tc.status))
+                       }(tc)
 
-	if err != nil {
-		t.Errorf("encountered an error: %v", err)
-		return
-	}
-	if result.Name != options.Name || result.Namespace != options.Namespace {
-		t.Errorf("incorrect instance was returned")
-		return
-	}
-	jobs, _ := fixture.List(testNamespace)
-	if len(jobs) != 2 {
-		t.Errorf("expecting 2 jobs in namespace, listing returned %v", len(jobs))
-		return
-	}
+                       result, err := fixture.Create(JobOptions{
+                               Name:          tc.name,
+                               Namespace:     tc.namespace,
+                               Image:         "busybox",
+                               Command:       []string{"sh", "-c", "sleep 300"},
+                               RestartPolicy: k8sTypes.RestartPolicyNever,
+                               Wait:          tc.wait,
+                       })
+
+                       if !tc.expectError && err != nil {
+                               t.Errorf("unexpected error: %v", err)
+                               return
+                       }
+                       if tc.expectError && err == nil {
+                               t.Errorf("Expected an error but none returned")
+                               return
+                       }
+                       // error expected and returned, it is ok
+                       if tc.expectError && err != nil {
+                               return
+                       }
+                       // error is not expected and none returned, result must be valid
+                       if result.Name != tc.name || result.Namespace != tc.namespace {
+                               t.Errorf("incorrect instance was returned")
+                               return
+                       }
+                       // FIXME: The fake client does not update the pod object in response to update
+                       // events added to the watcher. Checking the status fails
+                       //if string(result.Status.Phase) != "Running"  {
+                       //      t.Errorf("pod is in incorrect state returned: %v", result)
+                       //      return
+                       //}
+               })
+       }
 }
 
 func TestJobs_List(t *testing.T) {
@@ -308,7 +383,7 @@ func TestJobs_Wait(t *testing.T) {
 			expectedResult: false,
 			timeout:        "5s",
 		},
-		{
+			{
 			test:           "wait job failed",
 			name:           "pod-running",
 			namespace:      testNamespace,
@@ -351,3 +426,4 @@ func TestJobs_Wait(t *testing.T) {
 		})
 	}
 }
+


### PR DESCRIPTION
Add option for waiting until the job is completes to job Create. if the job has not completed after a given timeout, an error is returned.

Closes https://github.com/grafana/xk6-kubernetes/issues/37