### PR TITLE
Auto cleanup jobs

### DIFF
--- a/examples/create-job-autodelete.js
+++ b/examples/create-job-autodelete.js
@@ -1,0 +1,35 @@
+
+import { sleep } from 'k6';
+import { Kubernetes } from 'k6/x/kubernetes';
+
+function getJobNames(nameSpace, kubernetes) {
+  return kubernetes.jobs.list(nameSpace).map(function(job){
+    return job.name
+  })
+}
+
+export default function () {
+  const kubernetes = new Kubernetes({
+    // config_path: "/path/to/kube/config", ~/.kube/config by default
+  })
+  const namespace = "default"
+  const jobName = "new-job"
+  const image = "busybox"
+  const command = ["sh",  "-c", "sleep 3"]
+
+  kubernetes.jobs.create({
+    namespace: namespace,
+    name: jobName,
+    image: image,
+    command: command,
+    wait: "10s",
+    autodelete: true
+  })
+  console.log("job completed")
+  sleep(3)  // wait for garbage collection
+  const jobPod = kubernetes.pods.list().find(pod => pod.name.startsWith(jobName))
+  console.log(jobPod)
+  if (!jobPod) {
+     console.log("pods deleted")
+  }
+}

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -37,6 +37,7 @@ type JobOptions struct {
 	Command       []string
 	RestartPolicy coreV1.RestartPolicy
 	Wait          string
+	Autodelete    bool
 }
 
 func (obj *Jobs) List(namespace string) ([]v1.Job, error) {
@@ -119,6 +120,10 @@ func (obj *Jobs) Create(options JobOptions) (v1.Job, error) {
 		},
 	}
 
+	if options.Autodelete {
+		ttl := int32(0)
+		newJob.Spec.TTLSecondsAfterFinished = &ttl
+	}
 	job, err := obj.client.BatchV1().Jobs(options.Namespace).Create(obj.ctx, &newJob, metav1.CreateOptions{})
 	if err != nil {
 		return v1.Job{}, err

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -57,7 +57,12 @@ func (obj *Jobs) Get(name, namespace string) (v1.Job, error) {
 }
 
 func (obj *Jobs) Delete(name, namespace string) error {
-	return obj.client.BatchV1().Jobs(namespace).Delete(obj.ctx, name, metav1.DeleteOptions{})
+
+	propagationPolicy := metav1.DeletePropagationBackground
+	options := metav1.DeleteOptions{
+		PropagationPolicy: &propagationPolicy,
+	}
+	return obj.client.BatchV1().Jobs(namespace).Delete(obj.ctx, name, options)
 }
 
 // Deprecated: Use Delete instead.


### PR DESCRIPTION
Add option to Create job for automatically delete job on completion and delete in cascade pods when the job is deleted.

Note to reviewers: the default behavior of job Delete has changed and pods are **always** deleted when the Job is deleted. This option was chose over adding options for controlling this behavior that will introduces a change in the API (mandatory additional parameter: `jobs.Delete(namespace, name, cascade)`)

closes: https://github.com/grafana/xk6-kubernetes/issues/47