### PR TITLE
Generic k8s interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,12 @@ The kinds of resources currently supported are:
 * Job
 * Namespace
 * Node
+* PersistentVolume
+* PersistentVolumeClaim
 * Pod
 * Secret
 * Service
+* StatefulSet
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ export default function () {
 }
 ```
 
-#### Creating a job using a yaml manifest
+#### Creating a job using a YAML manifest
 ```javascript
 import { Kubernetes } from 'k6/x/kubernetes';
 

--- a/examples/create_get_list_delete_pod.js
+++ b/examples/create_get_list_delete_pod.js
@@ -27,12 +27,12 @@ export default function(){
 
         var pod = k8s.get(podSpec.kind, podSpec.metadata.name, podSpec.metadata.namespace)
         if (podSpec.metadata.name != pod.metadata.name) {
-                throw new Error("Fetch by name did not return the Service. Expected: " + podSpec.metadata.name + " but got: " + fetched.name)
+                throw new Error("fetch by name did not return the Pod. Expected: " + podSpec.metadata.name + " but got: " + fetched.name)
         }
 
         const pods = k8s.list(podSpec.kind, podSpec.metadata.namespace)
         if (pods === undefined || pods.length < 1) {
-                throw new Error("Expected listing with 1 Pod")
+                throw new Error("expected listing with 1 Pod")
         }
 
         k8s.delete(podSpec.kind, podSpec.metadata.name, podSpec.metadata.namespace)
@@ -41,6 +41,6 @@ export default function(){
         sleep(5)
 
         if (k8s.list(podSpec.kind, podSpec.metadata.namespace).length != 0) {
-                throw new Error("Deletion failed to remove pod")
+                throw new Error("deletion failed to remove pod")
         }
 }

--- a/examples/create_get_list_delete_pod.js
+++ b/examples/create_get_list_delete_pod.js
@@ -1,0 +1,46 @@
+import { Kubernetes } from 'k6/x/kubernetes'
+import { sleep } from 'k6'
+
+const k8s = new Kubernetes()
+
+const podSpec = {
+    apiVersion: "v1",
+    kind:       "Pod",
+    metadata: {
+        name:      "busybox",
+        namespace: "default"
+    },
+    spec: {
+        containers: [
+            {
+                name:    "busybox",
+                image:   "busybox",
+                command: ["sh", "-c", "sleep 30"]
+            }
+        ]
+    }
+}
+
+export default function(){
+        var created = k8s.create(podSpec)
+        console.log("pod '" + created.metadata.name +"' created")
+
+        var pod = k8s.get(podSpec.kind, podSpec.metadata.name, podSpec.metadata.namespace)
+        if (podSpec.metadata.name != pod.metadata.name) {
+                throw new Error("Fetch by name did not return the Service. Expected: " + podSpec.metadata.name + " but got: " + fetched.name)
+        }
+
+        const pods = k8s.list(podSpec.kind, podSpec.metadata.namespace)
+        if (pods === undefined || pods.length < 1) {
+                throw new Error("Expected listing with 1 Pod")
+        }
+
+        k8s.delete(podSpec.kind, podSpec.metadata.name, podSpec.metadata.namespace)
+        
+        // give time for the pod to be deleted
+        sleep(5)
+
+        if (k8s.list(podSpec.kind, podSpec.metadata.namespace).length != 0) {
+                throw new Error("Deletion failed to remove pod")
+        }
+}

--- a/internal/testutils/fake.go
+++ b/internal/testutils/fake.go
@@ -7,8 +7,11 @@ import (
 )
 
 // NewFakeDynamic creates a new instance of a fake dynamic client with a default scheme
-func NewFakeDynamic() *dynamicfake.FakeDynamicClient {
+func NewFakeDynamic() (*dynamicfake.FakeDynamicClient, error) {
 	scheme := runtime.NewScheme()
-	fake.AddToScheme(scheme)
-	return dynamicfake.NewSimpleDynamicClient(scheme)
+	err := fake.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
+	return dynamicfake.NewSimpleDynamicClient(scheme), nil
 }

--- a/internal/testutils/fake.go
+++ b/internal/testutils/fake.go
@@ -1,0 +1,14 @@
+package testutils
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// NewFakeDynamic creates a new instance of a fake dynamic client with a default scheme
+func NewFakeDynamic() *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	fake.AddToScheme(scheme)
+	return dynamicfake.NewSimpleDynamicClient(scheme)
+}

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -140,7 +140,6 @@ func (mi *ModuleInstance) newClient(c goja.ConstructorCall) *goja.Object {
 			common.Throw(rt, err)
 		}
 		obj.Kubernetes = k8s
-
 	} else {
 		// Pre-configured dynamic client is injected for unit testing
 		k8s, err := api.NewFromConfig(

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -463,10 +463,14 @@ func TestGenericApiIsScriptable(t *testing.T) {
 
 	tenv := setupTestEnv(t)
 
+	dynamic, err := localutils.NewFakeDynamic()
+	if err != nil {
+		t.Errorf("unexpected error creating fake client %v", err)
+	}
 	tenv.Module.clientset = fake.NewSimpleClientset()
-	tenv.Module.dynamic = localutils.NewFakeDynamic()
+	tenv.Module.dynamic = dynamic
 
-	_, err := tenv.Runtime.RunString(`
+	_, err = tenv.Runtime.RunString(`
 const k8s = new Kubernetes()
 
 const podSpec = {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -20,14 +20,17 @@ import (
 // TODO: complete with most common kinds
 func knownKinds(kind string) (schema.GroupVersionResource, error) {
 	kindMapping := map[string]schema.GroupVersionResource{
-		"ConfigMap":  {Group: "", Version: "v1", Resource: "configmaps"},
-		"Deployment": {Group: "apps", Version: "v1", Resource: "deployments"},
-		"Job":        {Group: "batch", Version: "v1", Resource: "jobs"},
-		"Pod":        {Group: "", Version: "v1", Resource: "pods"},
-		"Namespace":  {Group: "", Version: "v1", Resource: "namespaces"},
-		"Node":       {Group: "", Version: "v1", Resource: "nodes"},
-		"Secret":     {Group: "", Version: "v1", Resource: "secrets"},
-		"Service":    {Group: "", Version: "v1", Resource: "services"},
+		"ConfigMap":             {Group: "", Version: "v1", Resource: "configmaps"},
+		"Deployment":            {Group: "apps", Version: "v1", Resource: "deployments"},
+		"Job":                   {Group: "batch", Version: "v1", Resource: "jobs"},
+		"PersistentVolume":      {Group: "", Version: "v1", Resource: "persistentvolumes"},
+		"PersistentVolumeClaim": {Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
+		"Pod":                   {Group: "", Version: "v1", Resource: "pods"},
+		"Namespace":             {Group: "", Version: "v1", Resource: "namespaces"},
+		"Node":                  {Group: "", Version: "v1", Resource: "nodes"},
+		"Secret":                {Group: "", Version: "v1", Resource: "secrets"},
+		"Service":               {Group: "", Version: "v1", Resource: "services"},
+		"StatefulSet":           {Group: "apps", Version: "v1", Resource: "statefulsets"},
 	}
 
 	gvk, found := kindMapping[kind]

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,0 +1,192 @@
+// Package kubernetes implements helper functions for manipulating resources in a
+// Kubernetes cluster.
+package api
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+// maps kinds to api resources
+// TODO: complete with most common kinds
+var knownKinds = map[string]schema.GroupVersionResource{
+	"ConfigMap":  {Group: "", Version: "v1", Resource: "configmaps"},
+	"Deployment": {Group: "apps", Version: "v1", Resource: "deployments"},
+	"Job":        {Group: "batch", Version: "v1", Resource: "jobs"},
+	"Pod":        {Group: "", Version: "v1", Resource: "pods"},
+	"Namespace":  {Group: "", Version: "v1", Resource: "namespaces"},
+	"Node":       {Group: "", Version: "v1", Resource: "nodes"},
+	"Secret":     {Group: "", Version: "v1", Resource: "secrets"},
+	"Service":    {Group: "", Version: "v1", Resource: "services"},
+}
+
+// Defines an interface that extends kubernetes interface[k8s.io/client-go/kubernetes.Interface] adding
+// generic functions that operate on any kind of object
+type Kubernetes interface {
+	Apply(manifest string) error
+	Create(obj map[string]interface{}) (map[string]interface{}, error)
+	Get(kind string, name string, namespace string) (map[string]interface{}, error)
+	List(kind string, namespace string) ([]map[string]interface{}, error)
+	Delete(kind string, name string, namespace string) error
+}
+
+// KubernetesConfig defines the configuration for creating a Kubernetes instance
+type KubernetesConfig struct {
+	// Context for executing kubernetes operations
+	Context context.Context
+	// kubernetes rest config
+	Config *rest.Config
+}
+
+// kubernetes Holds the reference to the helpers for interacting with kubernetes
+type kubernetes struct {
+	ctx        context.Context
+	client     dynamic.Interface
+	serializer runtime.Serializer
+}
+
+// NewFromConfig returns a Kubernetes instance
+func NewFromConfig(c KubernetesConfig) (Kubernetes, error) {
+	dynamic, err := dynamic.NewForConfig(c.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := c.Context
+	if ctx == nil {
+		ctx = context.TODO()
+	}
+
+	return &kubernetes{
+		ctx:        ctx,
+		client:     dynamic,
+		serializer: yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme),
+	}, nil
+}
+
+// Apply creates a resource in a kubernetes cluster from a yaml manifest
+func (k *kubernetes) Apply(manifest string) error {
+	uObj := &unstructured.Unstructured{}
+	_, gvk, err := k.serializer.Decode([]byte(manifest), nil, uObj)
+	if err != nil {
+		return err
+	}
+	resource, known := knownKinds[gvk.Kind]
+	if !known {
+		return fmt.Errorf("unknown kind: '%s'", gvk.Kind)
+	}
+
+	namespace := uObj.GetNamespace()
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	_, err = k.client.Resource(resource).
+		Namespace(namespace).
+		Create(
+			k.ctx,
+			uObj,
+			metav1.CreateOptions{},
+		)
+
+	return err
+}
+
+// Create creates a resource in a kubernetes cluster from a yaml manifest
+func (k *kubernetes) Create(obj map[string]interface{}) (map[string]interface{}, error) {
+	uObj := &unstructured.Unstructured{
+		Object: obj,
+	}
+
+	gvk := uObj.GroupVersionKind()
+	namespace := uObj.GetNamespace()
+	if namespace == "" {
+		namespace = "default"
+	}
+	resource, known := knownKinds[gvk.Kind]
+	if !known {
+		return nil, fmt.Errorf("unknown kind: '%s'", gvk.Kind)
+	}
+
+	resp, err := k.client.Resource(resource).
+		Namespace(namespace).
+		Create(
+			k.ctx,
+			uObj,
+			metav1.CreateOptions{},
+		)
+
+	if err != nil {
+		return nil, err
+	}
+	return resp.UnstructuredContent(), nil
+}
+
+// Get returns an object given its kind, name and namespace
+func (k *kubernetes) Get(kind string, name string, namespace string) (map[string]interface{}, error) {
+	resource, known := knownKinds[kind]
+	if !known {
+		return nil, fmt.Errorf("unknown kind: '%s'", kind)
+	}
+
+	resp, err := k.client.
+		Resource(resource).
+		Namespace(namespace).
+		Get(
+			k.ctx,
+			name,
+			metav1.GetOptions{},
+		)
+
+	if err != nil {
+		return nil, err
+	}
+	return resp.UnstructuredContent(), nil
+}
+
+// List returns a list of objects given its kind and namespace
+func (k *kubernetes) List(kind string, namespace string) ([]map[string]interface{}, error) {
+	resource, known := knownKinds[kind]
+	if !known {
+		return nil, fmt.Errorf("unknown kind: '%s'", kind)
+	}
+
+	resp, err := k.client.
+		Resource(resource).
+		Namespace(namespace).
+		List(k.ctx, metav1.ListOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var list []map[string]interface{}
+	for _, uObj := range resp.Items {
+		list = append(list, uObj.UnstructuredContent())
+	}
+	return list, nil
+}
+
+// Delete deletes an object given its kind, name and namespace
+func (k *kubernetes) Delete(kind string, name string, namespace string) error {
+	resource, known := knownKinds[kind]
+	if !known {
+		return fmt.Errorf("unknown kind: '%s'", kind)
+	}
+
+	err := k.client.
+		Resource(resource).
+		Namespace(namespace).
+		Delete(k.ctx, name, metav1.DeleteOptions{})
+
+	return err
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -60,7 +60,7 @@ type KubernetesConfig struct {
 	Client dynamic.Interface
 }
 
-// kubernetes Holds the reference to the helpers for interacting with kubernetes
+// kubernetes holds the reference to the helpers for interacting with kubernetes
 type kubernetes struct {
 	ctx        context.Context
 	client     dynamic.Interface
@@ -90,7 +90,7 @@ func NewFromConfig(c KubernetesConfig) (Kubernetes, error) {
 	}, nil
 }
 
-// Apply creates a resource in a kubernetes cluster from a yaml manifest
+// Apply creates a resource in a kubernetes cluster from a YAML manifest
 func (k *kubernetes) Apply(manifest string) error {
 	uObj := &unstructured.Unstructured{}
 	_, gvk, err := k.serializer.Decode([]byte(manifest), nil, uObj)
@@ -117,7 +117,7 @@ func (k *kubernetes) Apply(manifest string) error {
 	return err
 }
 
-// Create creates a resource in a kubernetes cluster from a yaml manifest
+// Create creates a resource in a kubernetes cluster from an object with its specification
 func (k *kubernetes) Create(obj map[string]interface{}) (map[string]interface{}, error) {
 	uObj := &unstructured.Unstructured{
 		Object: obj,

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -9,56 +9,64 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 )
 
-var podSpec = map[string]interface{}{
-	"apiVersion": "v1",
-	"kind":       "Pod",
-	"metadata": map[string]interface{}{
-		"name":      "busybox",
-		"namespace": "testns",
-	},
-	"spec": map[string]interface{}{
-		"containers": []interface{}{
-			map[string]interface{}{
-				"name":    "busybox",
-				"image":   "busybox",
-				"command": []interface{}{"sh", "-c", "sleep 30"},
+func podSpec() map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      "busybox",
+			"namespace": "testns",
+		},
+		"spec": map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{
+					"name":    "busybox",
+					"image":   "busybox",
+					"command": []interface{}{"sh", "-c", "sleep 30"},
+				},
 			},
 		},
-	},
+	}
 }
 
-var JobSpec = map[string]interface{}{
-	"apiVersion": "apps/v1",
-	"kind":       "Job",
-	"metadata": map[string]interface{}{
-		"name":      "busybox",
-		"namespace": "testns",
-	},
-	"spec": map[string]interface{}{
-		"template": map[string]interface{}{
-			"spec": map[string]interface{}{
-				"containers": []interface{}{
-					map[string]interface{}{
-						"name":    "busybox",
-						"image":   "busybox",
-						"command": []interface{}{"sh", "-c", "sleep 30"},
+func jobSpec() map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Job",
+		"metadata": map[string]interface{}{
+			"name":      "busybox",
+			"namespace": "testns",
+		},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":    "busybox",
+							"image":   "busybox",
+							"command": []interface{}{"sh", "-c", "sleep 30"},
+						},
 					},
 				},
 			},
 		},
-	},
+	}
 }
 
-func newForTest() *kubernetes {
-	client := testutils.NewFakeDynamic()
+func newForTest() (*kubernetes, error) {
+	client, err := testutils.NewFakeDynamic()
+	if err != nil {
+		return nil, err
+	}
 	return &kubernetes{
 		ctx:        context.TODO(),
 		client:     client,
 		serializer: yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme),
-	}
+	}, nil
 }
 
 func TestCreateGetListDelete(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		test string
 		obj  map[string]interface{}
@@ -68,14 +76,14 @@ func TestCreateGetListDelete(t *testing.T) {
 	}{
 		{
 			test: "Create Get List Delete Pods",
-			obj:  podSpec,
+			obj:  podSpec(),
 			kind: "Pod",
 			name: "busybox",
 			ns:   "testns",
 		},
 		{
 			test: "Create Get List Delete Jobs",
-			obj:  JobSpec,
+			obj:  jobSpec(),
 			kind: "Job",
 			name: "busybox",
 			ns:   "testns",
@@ -83,42 +91,51 @@ func TestCreateGetListDelete(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		k := newForTest()
-		_, err := k.Create(tc.obj)
-		if err != nil {
-			t.Errorf("failed %v", err)
-			return
-		}
+		tc := tc
+		t.Run(tc.test, func(t *testing.T) {
+			t.Parallel()
+			k, err := newForTest()
+			if err != nil {
+				t.Errorf("failed %v", err)
+				return
+			}
+			_, err = k.Create(tc.obj)
+			if err != nil {
+				t.Errorf("failed %v", err)
+				return
+			}
 
-		obj, err := k.Get(tc.kind, tc.name, tc.ns)
-		if err != nil {
-			t.Errorf("failed %v", err)
-			return
-		}
-		if obj == nil {
-			t.Errorf("invalid value returned")
-			return
-		}
-		pods, err := k.List(tc.kind, tc.ns)
-		if err != nil {
-			t.Errorf("failed to get list of %ss: %v", tc.kind, err)
-			return
-		}
+			obj, err := k.Get(tc.kind, tc.name, tc.ns)
+			if err != nil {
+				t.Errorf("failed %v", err)
+				return
+			}
+			if obj == nil {
+				t.Errorf("invalid value returned")
+				return
+			}
+			pods, err := k.List(tc.kind, tc.ns)
+			if err != nil {
+				t.Errorf("failed to get list of %ss: %v", tc.kind, err)
+				return
+			}
 
-		if len(pods) == 0 {
-			t.Errorf("expected one %s but none received", tc.kind)
-			return
-		}
+			if len(pods) == 0 {
+				t.Errorf("expected one %s but none received", tc.kind)
+				return
+			}
 
-		err = k.Delete(tc.kind, tc.name, tc.ns)
-		if err != nil {
-			t.Errorf("failed to delete pod: %v", err)
-			return
-		}
+			err = k.Delete(tc.kind, tc.name, tc.ns)
+			if err != nil {
+				t.Errorf("failed to delete pod: %v", err)
+				return
+			}
+		})
 	}
 }
 
-var podManifest = `
+func podManifest() string {
+	return `
 apiVersion: v1
 kind: Pod
 metadata:
@@ -130,8 +147,10 @@ spec:
     image: busybox
     command: ["sleep", "300"]
 `
+}
 
 func TestApply(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		test     string
 		manifest string
@@ -141,7 +160,7 @@ func TestApply(t *testing.T) {
 	}{
 		{
 			test:     "Apply pod manifest",
-			manifest: podManifest,
+			manifest: podManifest(),
 			kind:     "Pod",
 			name:     "busybox",
 			ns:       "testns",
@@ -149,21 +168,29 @@ func TestApply(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		k := newForTest()
-		err := k.Apply(tc.manifest)
-		if err != nil {
-			t.Errorf("failed %v", err)
-			return
-		}
+		tc := tc
+		t.Run(tc.test, func(t *testing.T) {
+			t.Parallel()
+			k, err := newForTest()
+			if err != nil {
+				t.Errorf("failed %v", err)
+				return
+			}
+			err = k.Apply(tc.manifest)
+			if err != nil {
+				t.Errorf("failed %v", err)
+				return
+			}
 
-		obj, err := k.Get(tc.kind, tc.name, tc.ns)
-		if err != nil {
-			t.Errorf("failed %v", err)
-			return
-		}
-		if obj == nil {
-			t.Errorf("invalid value returned")
-			return
-		}
+			obj, err := k.Get(tc.kind, tc.name, tc.ns)
+			if err != nil {
+				t.Errorf("failed %v", err)
+				return
+			}
+			if obj == nil {
+				t.Errorf("invalid value returned")
+				return
+			}
+		})
 	}
 }

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -1,0 +1,173 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var podSpec = map[string]interface{}{
+	"apiVersion": "v1",
+	"kind":       "Pod",
+	"metadata": map[string]interface{}{
+		"name":      "busybox",
+		"namespace": "testns",
+	},
+	"spec": map[string]interface{}{
+		"containers": []interface{}{
+			map[string]interface{}{
+				"name":    "busybox",
+				"image":   "busybox",
+				"command": []interface{}{"sh", "-c", "sleep 30"},
+			},
+		},
+	},
+}
+
+var JobSpec = map[string]interface{}{
+	"apiVersion": "apps/v1",
+	"kind":       "Job",
+	"metadata": map[string]interface{}{
+		"name":      "busybox",
+		"namespace": "testns",
+	},
+	"spec": map[string]interface{}{
+		"template": map[string]interface{}{
+			"spec": map[string]interface{}{
+				"containers": []interface{}{
+					map[string]interface{}{
+						"name":    "busybox",
+						"image":   "busybox",
+						"command": []interface{}{"sh", "-c", "sleep 30"},
+					},
+				},
+			},
+		},
+	},
+}
+
+func newForTest() *kubernetes {
+	scheme := runtime.NewScheme()
+	fake.AddToScheme(scheme)
+	client := dynamicfake.NewSimpleDynamicClient(scheme)
+	return &kubernetes{
+		ctx:        context.TODO(),
+		client:     client,
+		serializer: yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme),
+	}
+}
+
+func TestCreateGetListDelete(t *testing.T) {
+	testCases := []struct {
+		test string
+		obj  map[string]interface{}
+		kind string
+		name string
+		ns   string
+	}{
+		{
+			test: "Create Get List Delete Pods",
+			obj:  podSpec,
+			kind: "Pod",
+			name: "busybox",
+			ns:   "testns",
+		},
+		{
+			test: "Create Get List Delete Jobs",
+			obj:  JobSpec,
+			kind: "Job",
+			name: "busybox",
+			ns:   "testns",
+		},
+	}
+
+	for _, tc := range testCases {
+		k := newForTest()
+		_, err := k.Create(tc.obj)
+		if err != nil {
+			t.Errorf("failed %v", err)
+			return
+		}
+
+		obj, err := k.Get(tc.kind, tc.name, tc.ns)
+		if err != nil {
+			t.Errorf("failed %v", err)
+			return
+		}
+		if obj == nil {
+			t.Errorf("invalid value returned")
+			return
+		}
+		pods, err := k.List(tc.kind, tc.ns)
+		if err != nil {
+			t.Errorf("failed to get list of %ss: %v", tc.kind, err)
+			return
+		}
+
+		if len(pods) == 0 {
+			t.Errorf("expected one %s but none received", tc.kind)
+			return
+		}
+
+		err = k.Delete(tc.kind, tc.name, tc.ns)
+		if err != nil {
+			t.Errorf("failed to delete pod: %v", err)
+			return
+		}
+	}
+}
+
+var podManifest = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  namespace: testns
+spec:
+  containers:
+  - name: busybox
+    image: busybox
+    command: ["sleep", "300"]
+`
+
+func TestApply(t *testing.T) {
+	testCases := []struct {
+		test     string
+		manifest string
+		kind     string
+		name     string
+		ns       string
+	}{
+		{
+			test:     "Apply pod manifest",
+			manifest: podManifest,
+			kind:     "Pod",
+			name:     "busybox",
+			ns:       "testns",
+		},
+	}
+
+	for _, tc := range testCases {
+		k := newForTest()
+		err := k.Apply(tc.manifest)
+		if err != nil {
+			t.Errorf("failed %v", err)
+			return
+		}
+
+		obj, err := k.Get(tc.kind, tc.name, tc.ns)
+		if err != nil {
+			t.Errorf("failed %v", err)
+			return
+		}
+		if obj == nil {
+			t.Errorf("invalid value returned")
+			return
+		}
+	}
+}

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/grafana/xk6-kubernetes/internal/testutils"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
-	dynamicfake "k8s.io/client-go/dynamic/fake"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
 var podSpec = map[string]interface{}{
@@ -52,9 +50,7 @@ var JobSpec = map[string]interface{}{
 }
 
 func newForTest() *kubernetes {
-	scheme := runtime.NewScheme()
-	fake.AddToScheme(scheme)
-	client := dynamicfake.NewSimpleDynamicClient(scheme)
+	client := testutils.NewFakeDynamic()
 	return &kubernetes{
 		ctx:        context.TODO(),
 		client:     client,


### PR DESCRIPTION
Implement Generic interface for creating, retrieving, listing, deleting Kubernetes resources of any of a set of supported kinds such as Pod, Job, Secret, Service (among others)

Closes #68 