### PR TITLE
Mark old APIs as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ This API offers methods for creating, retrieving, listing and deleting resources
 The kinds of resources currently supported are:
 * ConfigMap
 * Deployment
+* Ingress
 * Job
 * Namespace
 * Node
@@ -216,17 +217,19 @@ export default function () {
       console.log(`"pod ${pod.metadata.name} not ready after ${timeout} seconds`)
   }
 }
+```
 
 ## Resource kind helpers
 
 This API offers a helper for each kind of Kubernetes resources supported (Pods, Deployments, Secrets, et cetera). For each one, an interface for creating, getting, listing and deleting objects is offered. 
 
->⚠️  This interface is deprecated and will be removed soon
+>⚠️ This interface is deprecated and will be removed soon
 > -
+Migrate to the usage of the generic resources API.
 </br>
 
 
-### Create a client:  `new Kubernetes(config)`
+### (Deprecated) Create a client:  `new Kubernetes(config)`
 
 Creates a Kubernetes client to interact with the Kubernetes cluster.
 
@@ -244,7 +247,7 @@ export default function () {
 }
 ```
 
-### `Client.config_maps`
+### (Deprecated) `Client.config_maps`
 
 |  Method     |   Description |                               |
 | ------------ | ------ | ---------------------------------------- |
@@ -266,7 +269,7 @@ export default function () {
 }
 ```
 
-### `Client.deployments`
+### (Deprecated) `Client.deployments`
 
 |  Method     |   Description | Example                              |
 | ------------ | ------ | ---------------------------------------- |
@@ -293,7 +296,7 @@ export default function () {
 ```
 
 
-### `Client.ingresses`
+### (Deprecated) `Client.ingresses`
 
 |  Method     |   Description |                               |
 | ------------ | ------ | ---------------------------------------- |
@@ -317,7 +320,7 @@ export default function () {
 }
 ```
 
-### `Client.jobs`
+### (Deprecated) `Client.jobs`
 
 |  Method     |   Description | Example                              |
 | ------------ | ------ | ---------------------------------------- |
@@ -354,7 +357,7 @@ export default function () {
 }
 ```
 
-### `Client.namespaces`
+### (Deprecated) `Client.namespaces`
 
 |  Method     |   Description |                               |
 | ------------ | ------ | ---------------------------------------- |
@@ -376,7 +379,7 @@ export default function () {
 }
 ```
 
-### `Client.nodes`
+### (Deprecated) `Client.nodes`
 
 |  Method     |   Description | Example                              |
 | ------------ | ------ | ---------------------------------------- |
@@ -391,7 +394,7 @@ export default function () {
 }
 ```
 
-### `Client.persistent_volumes`
+### (Deprecated) `Client.persistent_volumes`
 
 |  Method     |   Description | Example                              |
 | ------------ | ------ | ---------------------------------------- |
@@ -412,7 +415,7 @@ export default function () {
 }
 ```
 
-### `Client.persistent_volumes_claims`
+### (Deprecated) `Client.persistent_volumes_claims`
 
 |  Method     |   Description | Example                              |
 | ------------ | ------ | ---------------------------------------- |
@@ -435,7 +438,7 @@ export default function () {
 }
 ```
 
-### `Client.pods`
+### (Deprecated) `Client.pods`
 
 |  Method     |   Description | Example                              |
 | ------------ | ------ | ---------------------------------------- |
@@ -480,7 +483,7 @@ export default function () {
 }
 ```
 
-### `Client.secrets`
+### (Deprecated) `Client.secrets`
 
 |  Method     |   Description | Example                              |
 | ------------ | ------ | ---------------------------------------- |
@@ -500,7 +503,7 @@ export default function () {
 }
 ```
 
-### `Client.services`
+### (Deprecated) `Client.services`
 
 |  Method     |   Description | Example                              |
 | ------------ | ------ | ---------------------------------------- |

--- a/pkg/configmaps/configmaps.go
+++ b/pkg/configmaps/configmaps.go
@@ -1,4 +1,6 @@
 // Package configmaps provides implementation of ConfigMap resources for Kubernetes
+//
+// Deprecated: Use the resources package instead.
 package configmaps
 
 import (
@@ -12,6 +14,8 @@ import (
 )
 
 // New creates a new instance backed by the provided client
+//
+// Deprecated: No longer used.
 func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.ListOptions) *ConfigMaps {
 	return &ConfigMaps{
 		client,
@@ -21,6 +25,8 @@ func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.Li
 }
 
 // ConfigMaps provides API for manipulating ConfigMap resources within a Kubernetes cluster
+//
+// Deprecated: No longer used in favor of generic resources.
 type ConfigMaps struct {
 	client      kubernetes.Interface
 	metaOptions metav1.ListOptions
@@ -28,6 +34,8 @@ type ConfigMaps struct {
 }
 
 // Apply creates the Kubernetes resource given the supplied YAML configuration
+//
+// Deprecated: Use resources.Apply instead.
 func (obj *ConfigMaps) Apply(yaml string, namespace string) (k8sTypes.ConfigMap, error) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	yamlobj, _, err := decode([]byte(yaml), nil, nil)
@@ -51,6 +59,8 @@ func (obj *ConfigMaps) Apply(yaml string, namespace string) (k8sTypes.ConfigMap,
 }
 
 // Create creates the Kubernetes resource given the supplied object
+//
+// Deprecated: Use resources.Create instead.
 func (obj *ConfigMaps) Create(
 	configMap k8sTypes.ConfigMap,
 	namespace string,
@@ -64,6 +74,8 @@ func (obj *ConfigMaps) Create(
 }
 
 // List returns a collection of ConfigMaps available within the namespace
+//
+// Deprecated: Use resources.List instead.
 func (obj *ConfigMaps) List(namespace string) ([]k8sTypes.ConfigMap, error) {
 	cms, err := obj.client.CoreV1().ConfigMaps(namespace).List(obj.ctx, obj.metaOptions)
 	if err != nil {
@@ -73,17 +85,22 @@ func (obj *ConfigMaps) List(namespace string) ([]k8sTypes.ConfigMap, error) {
 }
 
 // Delete removes the named ConfigMap from the namespace
+//
+// Deprecated: Use resources.Delete instead.
 func (obj *ConfigMaps) Delete(name, namespace string, opts metav1.DeleteOptions) error {
 	return obj.client.CoreV1().ConfigMaps(namespace).Delete(obj.ctx, name, opts)
 }
 
 // Kill removes the named ConfigMap from the namespace
-// Deprecated: Use Delete instead.
+//
+// Deprecated: Use resources.Delete instead.
 func (obj *ConfigMaps) Kill(name, namespace string, opts metav1.DeleteOptions) error {
 	return obj.Delete(name, namespace, opts)
 }
 
 // Get returns the named ConfigMaps instance within the namespace if available
+//
+// Deprecated: Use resources.Get instead.
 func (obj *ConfigMaps) Get(name, namespace string, opts metav1.GetOptions) (k8sTypes.ConfigMap, error) {
 	cm, err := obj.client.CoreV1().ConfigMaps(namespace).Get(obj.ctx, name, opts)
 	if err != nil {

--- a/pkg/deployments/deployments.go
+++ b/pkg/deployments/deployments.go
@@ -1,4 +1,6 @@
 // Package deployments provides implementation of Deployment resources for Kubernetes
+//
+// Deprecated: Use the resources package instead.
 package deployments
 
 import (
@@ -12,6 +14,8 @@ import (
 )
 
 // New creates a new instance backed by the provided client
+//
+// Deprecated: No longer used.
 func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.ListOptions) *Deployments {
 	return &Deployments{
 		client,
@@ -21,6 +25,8 @@ func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.Li
 }
 
 // Deployments provides API for manipulating Deployment resources within a Kubernetes cluster
+//
+// Deprecated: No longer used in favor of generic resources.
 type Deployments struct {
 	client      kubernetes.Interface
 	metaOptions metav1.ListOptions
@@ -28,6 +34,8 @@ type Deployments struct {
 }
 
 // Apply creates the Kubernetes resource given the supplied YAML configuration
+//
+// Deprecated: Use resources.Apply instead.
 func (obj *Deployments) Apply(yaml string, namespace string) (k8sTypes.Deployment, error) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	yamlobj, _, err := decode([]byte(yaml), nil, nil)
@@ -51,6 +59,8 @@ func (obj *Deployments) Apply(yaml string, namespace string) (k8sTypes.Deploymen
 }
 
 // Create creates the Kubernetes resource given the supplied object
+//
+// Deprecated: Use resources.Create instead.
 func (obj *Deployments) Create(
 	deployment k8sTypes.Deployment,
 	namespace string,
@@ -64,6 +74,8 @@ func (obj *Deployments) Create(
 }
 
 // List returns a collection of Deployments available within the namespace
+//
+// Deprecated: Use resources.List instead.
 func (obj *Deployments) List(namespace string) ([]k8sTypes.Deployment, error) {
 	dps, err := obj.client.AppsV1().Deployments(namespace).List(obj.ctx, obj.metaOptions)
 	if err != nil {
@@ -73,17 +85,22 @@ func (obj *Deployments) List(namespace string) ([]k8sTypes.Deployment, error) {
 }
 
 // Delete removes the named Deployment from the namespace
+//
+// Deprecated: Use resources.Delete instead.
 func (obj *Deployments) Delete(name, namespace string, opts metav1.DeleteOptions) error {
 	return obj.client.AppsV1().Deployments(namespace).Delete(obj.ctx, name, opts)
 }
 
 // Kill removes the named Deployment from the namespace
-// Deprecated: Use Delete instead.
+//
+// Deprecated: Use resources.Delete instead.
 func (obj *Deployments) Kill(name, namespace string, opts metav1.DeleteOptions) error {
 	return obj.Delete(name, namespace, opts)
 }
 
 // Get returns the named Deployments instance within the namespace if available
+//
+// Deprecated: Use resources.Get instead.
 func (obj *Deployments) Get(name, namespace string, opts metav1.GetOptions) (k8sTypes.Deployment, error) {
 	dp, err := obj.client.AppsV1().Deployments(namespace).Get(obj.ctx, name, opts)
 	if err != nil {

--- a/pkg/ingresses/ingresses.go
+++ b/pkg/ingresses/ingresses.go
@@ -1,4 +1,6 @@
 // Package ingresses provides implementation of Ingress resources for Kubernetes
+//
+// Deprecated: Use the resources package instead.
 package ingresses
 
 import (
@@ -12,6 +14,8 @@ import (
 )
 
 // New creates a new instance backed by the provided client
+//
+// Deprecated: No longer used.
 func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.ListOptions) *Ingresses {
 	return &Ingresses{
 		client,
@@ -21,6 +25,8 @@ func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.Li
 }
 
 // Ingresses provides API for manipulating Ingress resources within a Kubernetes cluster
+//
+// Deprecated: No longer used in favor of generic resources.
 type Ingresses struct {
 	client      kubernetes.Interface
 	metaOptions metav1.ListOptions
@@ -28,6 +34,8 @@ type Ingresses struct {
 }
 
 // Apply creates the Kubernetes resource given the supplied YAML configuration
+//
+// Deprecated: Use resources.Apply instead.
 func (obj *Ingresses) Apply(yaml string, namespace string) (k8sTypes.Ingress, error) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	yamlobj, _, err := decode([]byte(yaml), nil, nil)
@@ -51,6 +59,8 @@ func (obj *Ingresses) Apply(yaml string, namespace string) (k8sTypes.Ingress, er
 }
 
 // Create creates the Kubernetes resource given the supplied object
+//
+// Deprecated: Use resources.Create instead.
 func (obj *Ingresses) Create(
 	ingress k8sTypes.Ingress,
 	namespace string,
@@ -64,6 +74,8 @@ func (obj *Ingresses) Create(
 }
 
 // List returns a collection of Ingresses available within the namespace
+//
+// Deprecated: Use resources.List instead.
 func (obj *Ingresses) List(namespace string) ([]k8sTypes.Ingress, error) {
 	ings, err := obj.client.NetworkingV1().Ingresses(namespace).List(obj.ctx, obj.metaOptions)
 	if err != nil {
@@ -73,17 +85,22 @@ func (obj *Ingresses) List(namespace string) ([]k8sTypes.Ingress, error) {
 }
 
 // Delete removes the named Ingress from the namespace
+//
+// Deprecated: Use resources.Delete instead.
 func (obj *Ingresses) Delete(name, namespace string, opts metav1.DeleteOptions) error {
 	return obj.client.NetworkingV1().Ingresses(namespace).Delete(obj.ctx, name, opts)
 }
 
 // Kill removes the named Ingress from the namespace
-// Deprecated: Use Delete instead.
+//
+// Deprecated: Use resources.Delete instead.
 func (obj *Ingresses) Kill(name, namespace string, opts metav1.DeleteOptions) error {
 	return obj.Delete(name, namespace, opts)
 }
 
 // Get returns the named Ingresses instance within the namespace if available
+//
+// Deprecated: Use resources.Get instead.
 func (obj *Ingresses) Get(name, namespace string, opts metav1.GetOptions) (k8sTypes.Ingress, error) {
 	ing, err := obj.client.NetworkingV1().Ingresses(namespace).Get(obj.ctx, name, opts)
 	if err != nil {

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -1,4 +1,6 @@
 // Package jobs provides implementation of Job resources for Kubernetes
+//
+// Deprecated: Use the resources package instead.
 package jobs
 
 import (
@@ -17,6 +19,8 @@ import (
 )
 
 // New creates a new instance backed by the provided client
+//
+// Deprecated: No longer used.
 func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.ListOptions) *Jobs {
 	return &Jobs{
 		client,
@@ -26,6 +30,8 @@ func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.Li
 }
 
 // Jobs provides API for manipulating Job resources within a Kubernetes cluster
+//
+// Deprecated: No longer used in favor of generic resources.
 type Jobs struct {
 	client      kubernetes.Interface
 	metaOptions metav1.ListOptions
@@ -33,6 +39,8 @@ type Jobs struct {
 }
 
 // JobOptions provide configuration settings for creation of Job resources
+//
+// Deprecated: No longer used in favor of generic resources.
 type JobOptions struct {
 	Namespace     string
 	Name          string
@@ -46,6 +54,8 @@ type JobOptions struct {
 }
 
 // List returns a collection of Jobs available within the namespace
+//
+// Deprecated: Use resources.List instead.
 func (obj *Jobs) List(namespace string) ([]v1.Job, error) {
 	result, err := obj.client.BatchV1().Jobs(namespace).List(obj.ctx, obj.metaOptions)
 	if err != nil {
@@ -55,6 +65,8 @@ func (obj *Jobs) List(namespace string) ([]v1.Job, error) {
 }
 
 // Get returns the named Jobs instance within the namespace if available
+//
+// Deprecated: Use resources.Get instead.
 func (obj *Jobs) Get(name, namespace string) (v1.Job, error) {
 	result, err := obj.client.BatchV1().Jobs(namespace).Get(obj.ctx, name, metav1.GetOptions{})
 	if err != nil {
@@ -64,6 +76,8 @@ func (obj *Jobs) Get(name, namespace string) (v1.Job, error) {
 }
 
 // Delete removes the named Job from the namespace
+//
+// Deprecated: Use resources.Delete instead.
 func (obj *Jobs) Delete(name, namespace string) error {
 	propagationPolicy := metav1.DeletePropagationBackground
 	options := metav1.DeleteOptions{
@@ -73,12 +87,15 @@ func (obj *Jobs) Delete(name, namespace string) error {
 }
 
 // Kill removes the named Job from the namespace
-// Deprecated: Use Delete instead.
+//
+// Deprecated: Use resources.Delete instead.
 func (obj *Jobs) Kill(name, namespace string) error {
 	return obj.Delete(name, namespace)
 }
 
 // Apply creates the Kubernetes resource given the supplied YAML configuration
+//
+// Deprecated: Use resources.Apply instead.
 func (obj *Jobs) Apply(yaml string, namespace string) (v1.Job, error) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	yamlobj, _, err := decode([]byte(yaml), nil, nil)
@@ -102,6 +119,8 @@ func (obj *Jobs) Apply(yaml string, namespace string) (v1.Job, error) {
 }
 
 // Create creates the Kubernetes resource given the supplied object
+//
+// Deprecated: Use resources.Create instead.
 func (obj *Jobs) Create(options JobOptions) (v1.Job, error) {
 	container := coreV1.Container{
 		Name:            options.Name,
@@ -161,6 +180,8 @@ func (obj *Jobs) Create(options JobOptions) (v1.Job, error) {
 }
 
 // WaitOptions specify the options for waiting for a Job to complete
+//
+// Deprecated: no longer used.
 type WaitOptions struct {
 	Name      string
 	Namespace string
@@ -181,6 +202,8 @@ func isCompleted(job *v1.Job) (bool, error) {
 }
 
 // Wait for all pods to complete
+//
+// Deprecated: No longer used.
 func (obj *Jobs) Wait(options WaitOptions) (bool, error) {
 	// wait for updates until completion
 	timeout, err := time.ParseDuration(options.Timeout)

--- a/pkg/namespaces/namespaces.go
+++ b/pkg/namespaces/namespaces.go
@@ -1,4 +1,6 @@
 // Package namespaces provides implementation of Namespace resources for Kubernetes
+//
+// Deprecated: Use the resources package instead.
 package namespaces
 
 import (
@@ -12,6 +14,8 @@ import (
 )
 
 // New creates a new instance backed by the provided client
+//
+// Deprecated: No longer used.
 func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.ListOptions) *Namespaces {
 	return &Namespaces{
 		client,
@@ -21,6 +25,8 @@ func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.Li
 }
 
 // Namespaces provides API for manipulating Namespace resources within a Kubernetes cluster
+//
+// Deprecated: No longer used in favor of generic resources.
 type Namespaces struct {
 	client      kubernetes.Interface
 	metaOptions metav1.ListOptions
@@ -28,6 +34,8 @@ type Namespaces struct {
 }
 
 // Apply creates the Kubernetes resource given the supplied YAML configuration
+//
+// Deprecated: Use resources.Apply instead.
 func (obj *Namespaces) Apply(yaml string) (k8sTypes.Namespace, error) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	yamlobj, _, err := decode([]byte(yaml), nil, nil)
@@ -51,6 +59,8 @@ func (obj *Namespaces) Apply(yaml string) (k8sTypes.Namespace, error) {
 }
 
 // Create creates the Kubernetes resource given the supplied object
+//
+// Deprecated: Use resources.Create instead.
 func (obj *Namespaces) Create(
 	namespace k8sTypes.Namespace,
 	opts metav1.CreateOptions,
@@ -63,6 +73,8 @@ func (obj *Namespaces) Create(
 }
 
 // List returns a collection of Namespaces available within the cluster
+//
+// Deprecated: Use resources.List instead.
 func (obj *Namespaces) List() ([]k8sTypes.Namespace, error) {
 	nss, err := obj.client.CoreV1().Namespaces().List(obj.ctx, obj.metaOptions)
 	if err != nil {
@@ -72,17 +84,22 @@ func (obj *Namespaces) List() ([]k8sTypes.Namespace, error) {
 }
 
 // Delete removes the named Namespace from the cluster
+//
+// Deprecated: Use resources.Delete instead.
 func (obj *Namespaces) Delete(name string, opts metav1.DeleteOptions) error {
 	return obj.client.CoreV1().Namespaces().Delete(obj.ctx, name, opts)
 }
 
 // Kill removes the named Namespace from the cluster
-// Deprecated: Use Delete instead.
+//
+// Deprecated: Use resources.Delete instead.
 func (obj *Namespaces) Kill(name string, opts metav1.DeleteOptions) error {
 	return obj.Delete(name, opts)
 }
 
 // Get returns the named Namespaces instance within the cluster if available
+//
+// Deprecated: Use resources.Get instead.
 func (obj *Namespaces) Get(name string, opts metav1.GetOptions) (k8sTypes.Namespace, error) {
 	ns, err := obj.client.CoreV1().Namespaces().Get(obj.ctx, name, opts)
 	if err != nil {

--- a/pkg/nodes/nodes.go
+++ b/pkg/nodes/nodes.go
@@ -1,4 +1,6 @@
 // Package nodes provides implementation of Node resources for Kubernetes
+//
+// Deprecated: Use the resources package instead.
 package nodes
 
 import (
@@ -10,6 +12,8 @@ import (
 )
 
 // New creates a new instance backed by the provided client
+//
+// Deprecated: No longer used.
 func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.ListOptions) *Nodes {
 	return &Nodes{
 		client,
@@ -19,6 +23,8 @@ func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.Li
 }
 
 // Nodes provides API for manipulating Node resources within a Kubernetes cluster
+//
+// Deprecated: No longer used in favor of generic resources.
 type Nodes struct {
 	client      kubernetes.Interface
 	metaOptions metav1.ListOptions
@@ -26,6 +32,8 @@ type Nodes struct {
 }
 
 // List returns a collection of Nodes comprising the cluster
+//
+// Deprecated: Use resources.List instead.
 func (obj *Nodes) List() ([]k8sTypes.Node, error) {
 	nodes, err := obj.client.CoreV1().Nodes().List(obj.ctx, obj.metaOptions)
 	if err != nil {

--- a/pkg/persistentvolumeclaims/persistentvolumeclaims.go
+++ b/pkg/persistentvolumeclaims/persistentvolumeclaims.go
@@ -1,4 +1,6 @@
 // Package persistentvolumeclaims provides implementation of PersistentVolumeClaim resources for Kubernetes
+//
+// Deprecated: Use the resources package instead.
 package persistentvolumeclaims
 
 import (
@@ -12,6 +14,8 @@ import (
 )
 
 // New creates a new instance backed by the provided client
+//
+// Deprecated: No longer used.
 func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.ListOptions) *PersistentVolumeClaims {
 	return &PersistentVolumeClaims{
 		client,
@@ -21,6 +25,8 @@ func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.Li
 }
 
 // PersistentVolumeClaims provides API for manipulating PersistentVolumeClaim resources within a Kubernetes cluster
+//
+// Deprecated: No longer used in favor of generic resources.
 type PersistentVolumeClaims struct {
 	client      kubernetes.Interface
 	metaOptions metav1.ListOptions
@@ -28,6 +34,8 @@ type PersistentVolumeClaims struct {
 }
 
 // Apply creates the Kubernetes resource given the supplied YAML configuration
+//
+// Deprecated: Use resources.Apply instead.
 func (obj *PersistentVolumeClaims) Apply(yaml string, namespace string) (k8sTypes.PersistentVolumeClaim, error) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	yamlobj, _, err := decode([]byte(yaml), nil, nil)
@@ -52,6 +60,8 @@ func (obj *PersistentVolumeClaims) Apply(yaml string, namespace string) (k8sType
 }
 
 // Create creates the Kubernetes resource given the supplied object
+//
+// Deprecated: Use resources.Create instead.
 func (obj *PersistentVolumeClaims) Create(
 	persistentvolumeclaim k8sTypes.PersistentVolumeClaim,
 	namespace string,
@@ -65,6 +75,8 @@ func (obj *PersistentVolumeClaims) Create(
 }
 
 // List returns a collection of PersistentVolumeClaims available within the namespace
+//
+// Deprecated: Use resources.List instead.
 func (obj *PersistentVolumeClaims) List(namespace string) ([]k8sTypes.PersistentVolumeClaim, error) {
 	pvcs, err := obj.client.CoreV1().PersistentVolumeClaims(namespace).List(obj.ctx, obj.metaOptions)
 	if err != nil {
@@ -74,11 +86,15 @@ func (obj *PersistentVolumeClaims) List(namespace string) ([]k8sTypes.Persistent
 }
 
 // Delete removes the named PersistentVolumeClaims from the namespace
+//
+// Deprecated: Use resources.Delete instead.
 func (obj *PersistentVolumeClaims) Delete(name, namespace string, opts metav1.DeleteOptions) error {
 	return obj.client.CoreV1().PersistentVolumeClaims(namespace).Delete(obj.ctx, name, opts)
 }
 
 // Get returns the named PersistentVolumeClaims instance within the namespace if available
+//
+// Deprecated: Use resources.Get instead.
 func (obj *PersistentVolumeClaims) Get(
 	name, namespace string, opts metav1.GetOptions,
 ) (k8sTypes.PersistentVolumeClaim, error) {

--- a/pkg/persistentvolumes/persistentvolumes.go
+++ b/pkg/persistentvolumes/persistentvolumes.go
@@ -1,4 +1,6 @@
 // Package persistentvolumes provides implementation of PersistentVolume resources for Kubernetes
+//
+// Deprecated: Use the resources package instead.
 package persistentvolumes
 
 import (
@@ -12,6 +14,8 @@ import (
 )
 
 // New creates a new instance backed by the provided client
+//
+// Deprecated: No longer used.
 func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.ListOptions) *PersistentVolumes {
 	return &PersistentVolumes{
 		client,
@@ -21,6 +25,8 @@ func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.Li
 }
 
 // PersistentVolumes provides API for manipulating PersistentVolume resources within a Kubernetes cluster
+//
+// Deprecated: No longer used in favor of generic resources.
 type PersistentVolumes struct {
 	client      kubernetes.Interface
 	metaOptions metav1.ListOptions
@@ -28,6 +34,8 @@ type PersistentVolumes struct {
 }
 
 // Apply creates the Kubernetes resource given the supplied YAML configuration
+//
+// Deprecated: Use resources.Apply instead.
 func (obj *PersistentVolumes) Apply(yaml string) (k8sTypes.PersistentVolume, error) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	yamlobj, _, err := decode([]byte(yaml), nil, nil)
@@ -51,6 +59,8 @@ func (obj *PersistentVolumes) Apply(yaml string) (k8sTypes.PersistentVolume, err
 }
 
 // Create creates the Kubernetes resource given the supplied object
+//
+// Deprecated: Use resources.Create instead.
 func (obj *PersistentVolumes) Create(
 	persistentvolume k8sTypes.PersistentVolume,
 	opts metav1.CreateOptions,
@@ -63,6 +73,8 @@ func (obj *PersistentVolumes) Create(
 }
 
 // List returns a collection of PersistentVolumes available within the cluster
+//
+// Deprecated: Use resources.List instead.
 func (obj *PersistentVolumes) List() ([]k8sTypes.PersistentVolume, error) {
 	pvs, err := obj.client.CoreV1().PersistentVolumes().List(obj.ctx, obj.metaOptions)
 	if err != nil {
@@ -72,11 +84,15 @@ func (obj *PersistentVolumes) List() ([]k8sTypes.PersistentVolume, error) {
 }
 
 // Delete removes the named PersistentVolumes from the cluster
+//
+// Deprecated: Use resources.Delete instead.
 func (obj *PersistentVolumes) Delete(name string, opts metav1.DeleteOptions) error {
 	return obj.client.CoreV1().PersistentVolumes().Delete(obj.ctx, name, opts)
 }
 
 // Get returns the named PersistentVolumes instance within the cluster if available
+//
+// Deprecated: Use resources.Get instead.
 func (obj *PersistentVolumes) Get(name string, opts metav1.GetOptions) (k8sTypes.PersistentVolume, error) {
 	pv, err := obj.client.CoreV1().PersistentVolumes().Get(obj.ctx, name, opts)
 	if err != nil {

--- a/pkg/pods/pods.go
+++ b/pkg/pods/pods.go
@@ -1,4 +1,6 @@
 // Package pods provides implementation of Pod resources for Kubernetes
+//
+// Deprecated: Use the resources package instead.
 package pods
 
 import (
@@ -28,6 +30,8 @@ const (
 )
 
 // New creates a new instance backed by the provided client
+//
+// Deprecated: No longer used.
 func New(ctx context.Context, client kubernetes.Interface, config *rest.Config, metaOptions metav1.ListOptions) *Pods {
 	return &Pods{
 		client,
@@ -38,6 +42,8 @@ func New(ctx context.Context, client kubernetes.Interface, config *rest.Config, 
 }
 
 // ExecOptions describe the command to be executed and the target container
+//
+// Deprecated: No longer used.
 type ExecOptions struct {
 	Namespace string   // namespace where the pod is running
 	Pod       string   // name of the Pod to execute the command in
@@ -47,12 +53,16 @@ type ExecOptions struct {
 }
 
 // ExecResult contains the output obtained from the execution of a command
+//
+// Deprecated: No longer used.
 type ExecResult struct {
 	Stdout []byte
 	Stderr []byte
 }
 
 // ContainerOptions describes a container to be started in a pod
+//
+// Deprecated: No longer used.
 type ContainerOptions struct {
 	Name         string // name of the container
 	Image        string // image to be attached
@@ -62,12 +72,16 @@ type ContainerOptions struct {
 }
 
 // EphemeralContainerOptions describes the options for creating an ephemeral container in a pod
+//
+// Deprecated: No longer used.
 type EphemeralContainerOptions struct {
 	ContainerOptions
 	Wait string
 }
 
 // Pods provides API for manipulating Pod resources within a Kubernetes cluster
+//
+// Deprecated: No longer used in favor of generic resources.
 type Pods struct {
 	client      kubernetes.Interface
 	config      *rest.Config
@@ -76,6 +90,8 @@ type Pods struct {
 }
 
 // PodOptions describe a Pod to be executed
+//
+// Deprecated: No longer used.
 type PodOptions struct {
 	Namespace     string // namespace where the pod will be executed
 	Name          string // name of the pod
@@ -87,9 +103,13 @@ type PodOptions struct {
 }
 
 // podConditionChecker defines a function that checks if a pod satisfies a condition
+//
+// Deprecated: No longer used.
 type podConditionChecker func(*k8sTypes.Pod) (bool, error)
 
 // List returns a collection of Pods available within the namespace
+//
+// Deprecated: Use resources.List instead.
 func (obj *Pods) List(namespace string) ([]k8sTypes.Pod, error) {
 	pods, err := obj.client.CoreV1().Pods(namespace).List(obj.ctx, obj.metaOptions)
 	if err != nil {
@@ -99,17 +119,22 @@ func (obj *Pods) List(namespace string) ([]k8sTypes.Pod, error) {
 }
 
 // Delete removes the named Pod from the namespace
+//
+// Deprecated: Use resources.Delete instead.
 func (obj *Pods) Delete(name, namespace string, opts metav1.DeleteOptions) error {
 	return obj.client.CoreV1().Pods(namespace).Delete(obj.ctx, name, opts)
 }
 
 // Kill removes the named Pod from the namespace
-// Deprecated: Use Delete instead.
+//
+// Deprecated: Use resources.Delete instead.
 func (obj *Pods) Kill(name, namespace string, opts metav1.DeleteOptions) error {
 	return obj.Delete(name, namespace, opts)
 }
 
 // Get returns the named Pods instance within the namespace if available
+//
+// Deprecated: Use resources.Get instead.
 func (obj *Pods) Get(name, namespace string) (k8sTypes.Pod, error) {
 	pods, err := obj.List(namespace)
 	if err != nil {
@@ -124,6 +149,8 @@ func (obj *Pods) Get(name, namespace string) (k8sTypes.Pod, error) {
 }
 
 // IsTerminating returns if the state of the named pod is currently terminating
+//
+// Deprecated: No longer used.
 func (obj *Pods) IsTerminating(name, namespace string) (bool, error) {
 	pod, err := obj.Get(name, namespace)
 	if err != nil {
@@ -133,6 +160,8 @@ func (obj *Pods) IsTerminating(name, namespace string) (bool, error) {
 }
 
 // Create runs a pod specified by the options
+//
+// Deprecated: Use resources.Create instead.
 func (obj *Pods) Create(options PodOptions) (k8sTypes.Pod, error) {
 	container := k8sTypes.Container{
 		Name:            options.Name,
@@ -186,6 +215,8 @@ func (obj *Pods) Create(options PodOptions) (k8sTypes.Pod, error) {
 }
 
 // WaitOptions for waiting for a Pod status
+//
+// Deprecated: No longer used.
 type WaitOptions struct {
 	Name      string // Pod name
 	Namespace string // Namespace where the pod is running
@@ -195,6 +226,8 @@ type WaitOptions struct {
 
 // Wait for the Pod to be in a given status up to given timeout and returns a boolean indicating if the status
 // was reached. If the pod is Failed returns error.
+//
+// Deprecated: No longer used.
 func (obj *Pods) Wait(options WaitOptions) (bool, error) {
 	if options.Status != Running && options.Status != Succeeded {
 		return false, errors.New("wait condition must be 'Running' or 'Succeeded'")
@@ -265,6 +298,8 @@ func (obj *Pods) waitForCondition(
 }
 
 // Exec executes a non-interactive command described in options and returns the stdout and stderr outputs
+//
+// Deprecated: No longer used.
 func (obj *Pods) Exec(options ExecOptions) (*ExecResult, error) {
 	req := obj.client.CoreV1().RESTClient().
 		Post().
@@ -310,6 +345,8 @@ func (obj *Pods) Exec(options ExecOptions) (*ExecResult, error) {
 
 // AddEphemeralContainer adds an ephemeral container to a running pod. The Pod is identified by name and namespace.
 // The container is described by options
+//
+// Deprecated: No longer used.
 func (obj *Pods) AddEphemeralContainer(name, namespace string, options EphemeralContainerOptions) error {
 	pod, err := obj.Get(name, namespace)
 	if err != nil {

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -1,4 +1,6 @@
 // Package secrets provides implementation of Secret resources for Kubernetes
+//
+// Deprecated: Use the resources package instead.
 package secrets
 
 import (
@@ -12,6 +14,8 @@ import (
 )
 
 // New creates a new instance backed by the provided client
+//
+// Deprecated: No longer used.
 func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.ListOptions) *Secrets {
 	return &Secrets{
 		client,
@@ -21,6 +25,8 @@ func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.Li
 }
 
 // Secrets provides API for manipulating Secret resources within a Kubernetes cluster
+//
+// Deprecated: No longer used in favor of generic resources.
 type Secrets struct {
 	client      kubernetes.Interface
 	metaOptions metav1.ListOptions
@@ -28,6 +34,8 @@ type Secrets struct {
 }
 
 // Apply creates the Kubernetes resource given the supplied YAML configuration
+//
+// Deprecated: Use resources.Apply instead.
 func (obj *Secrets) Apply(yaml string, namespace string) (k8sTypes.Secret, error) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	yamlobj, _, err := decode([]byte(yaml), nil, nil)
@@ -51,6 +59,8 @@ func (obj *Secrets) Apply(yaml string, namespace string) (k8sTypes.Secret, error
 }
 
 // Create creates the Kubernetes resource given the supplied object
+//
+// Deprecated: Use resources.Create instead.
 func (obj *Secrets) Create(
 	secret k8sTypes.Secret,
 	namespace string,
@@ -64,6 +74,8 @@ func (obj *Secrets) Create(
 }
 
 // List returns a collection of Secrets available within the namespace
+//
+// Deprecated: Use resources.List instead.
 func (obj *Secrets) List(namespace string) ([]k8sTypes.Secret, error) {
 	scrts, err := obj.client.CoreV1().Secrets(namespace).List(obj.ctx, obj.metaOptions)
 	if err != nil {
@@ -73,17 +85,22 @@ func (obj *Secrets) List(namespace string) ([]k8sTypes.Secret, error) {
 }
 
 // Delete removes the named Secret from the namespace
+//
+// Deprecated: Use resources.Delete instead.
 func (obj *Secrets) Delete(name, namespace string, opts metav1.DeleteOptions) error {
 	return obj.client.CoreV1().Secrets(namespace).Delete(obj.ctx, name, opts)
 }
 
 // Kill removes the named Secret from the namespace
-// Deprecated: Use Delete instead.
+//
+// Deprecated: Use resources.Delete instead.
 func (obj *Secrets) Kill(name, namespace string, opts metav1.DeleteOptions) error {
 	return obj.Delete(name, namespace, opts)
 }
 
 // Get returns the named Secrets instance within the namespace if available
+//
+// Deprecated: Use resources.Get instead.
 func (obj *Secrets) Get(name, namespace string, opts metav1.GetOptions) (k8sTypes.Secret, error) {
 	scrt, err := obj.client.CoreV1().Secrets(namespace).Get(obj.ctx, name, opts)
 	if err != nil {

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -1,4 +1,6 @@
 // Package services provides implementation of Service resources for Kubernetes
+//
+// Deprecated: Use the resources package instead.
 package services
 
 import (
@@ -12,6 +14,8 @@ import (
 )
 
 // New creates a new instance backed by the provided client
+//
+// Deprecated: No longer used.
 func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.ListOptions) *Services {
 	return &Services{
 		client,
@@ -21,6 +25,8 @@ func New(ctx context.Context, client kubernetes.Interface, metaOptions metav1.Li
 }
 
 // Services provides API for manipulating Service resources within a Kubernetes cluster
+//
+// Deprecated: No longer used in favor of generic resources.
 type Services struct {
 	client      kubernetes.Interface
 	metaOptions metav1.ListOptions
@@ -28,6 +34,8 @@ type Services struct {
 }
 
 // Apply creates the Kubernetes resource given the supplied YAML configuration
+//
+// Deprecated: Use resources.Apply instead.
 func (obj *Services) Apply(yaml string, namespace string) (k8sTypes.Service, error) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	yamlobj, _, err := decode([]byte(yaml), nil, nil)
@@ -51,6 +59,8 @@ func (obj *Services) Apply(yaml string, namespace string) (k8sTypes.Service, err
 }
 
 // Create creates the Kubernetes resource given the supplied object
+//
+// Deprecated: Use resources.Create instead.
 func (obj *Services) Create(
 	service k8sTypes.Service,
 	namespace string,
@@ -64,6 +74,8 @@ func (obj *Services) Create(
 }
 
 // List returns a collection of Services available within the namespace
+//
+// Deprecated: Use resources.List instead.
 func (obj *Services) List(namespace string) ([]k8sTypes.Service, error) {
 	svcs, err := obj.client.CoreV1().Services(namespace).List(obj.ctx, obj.metaOptions)
 	if err != nil {
@@ -73,17 +85,22 @@ func (obj *Services) List(namespace string) ([]k8sTypes.Service, error) {
 }
 
 // Delete removes the named Service from the namespace
+//
+// Deprecated: Use resources.Delete instead.
 func (obj *Services) Delete(name, namespace string, opts metav1.DeleteOptions) error {
 	return obj.client.CoreV1().Services(namespace).Delete(obj.ctx, name, opts)
 }
 
 // Kill removes the named Service from the namespace
-// Deprecated: Use Delete instead.
+//
+// Deprecated: Use resources.Delete instead.
 func (obj *Services) Kill(name, namespace string, opts metav1.DeleteOptions) error {
 	return obj.Delete(name, namespace, opts)
 }
 
 // Get returns the named Services instance within the namespace if available
+//
+// Deprecated: Use resources.Get instead.
 func (obj *Services) Get(name, namespace string, opts metav1.GetOptions) (k8sTypes.Service, error) {
 	svc, err := obj.client.CoreV1().Services(namespace).Get(obj.ctx, name, opts)
 	if err != nil {


### PR DESCRIPTION
Use the API docs to officially deprecate old usages prior to removal. Also fixes a bug in the documentation which caused the deprecation warning there to not display correctly.

Signed-off-by: javaducky <javaducky@gmail.com>