### PR TITLE
fix: readme invalid header

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The API assumes a `kubeconfig` configuration is available at any of the followin
 * at `$HOME/.kube`
 
 
-# API
+# APIs
 
 ## Generic API
 


### PR DESCRIPTION
Link on line 27 doesn't work because heading is not matches.
https://github.com/grafana/xk6-kubernetes/blob/693426da9079a2edd423e90b2a0135f06ba7173f/README.md?plain=1#L27