### PR TITLE
fix linting errors and add linter as CI check

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,6 +1,8 @@
 name: Lint
 
-on: push
+on:
+  push:
+  pull_request:
 
 jobs:
   check-modules:

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // Required for access to GKE and AKS
-	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
 )
@@ -149,7 +148,7 @@ func getClientConfig(options KubeConfig) (*rest.Config, error) {
 	kubeconfig := options.ConfigPath
 	if kubeconfig == "" {
 		// are we in-cluster?
-		config, err := restclient.InClusterConfig()
+		config, err := rest.InClusterConfig()
 		if err == nil {
 			return config, nil
 		}


### PR DESCRIPTION
On [my previous commit ](https://github.com/grafana/xk6-kubernetes/commit/ad619e1c3def82a42f0bb0d387f63725ba3f0143)I introduced an error because I duplicated an already existing import.

This PR fixes that issue and also adds the linter as CI check to prevent this incident in the future