### PR TITLE
Remove list of supported resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,21 +69,6 @@ This API offers methods for creating, retrieving, listing and deleting resources
 |                | namespace |
 | update         | spec object | updates an existing resource
 
-
-The kinds of resources currently supported are:
-* [ConfigMap](examples/configmap_operations.js)
-* [Deployment](examples/deployment_operations.js)
-* [Ingress](examples/ingress_operations.js)
-* [Job](examples/job_operations.js)
-* [Namespace](examples/namespace_operations.js)
-* [Node](examples/node_operations.js)
-* [PersistentVolume](examples/persistentvolume_operations.js)
-* [PersistentVolumeClaim](examples/persistentvolumeclaim_operations.js)
-* [Pod](examples/pod_operations.js)
-* [Secret](examples/secret_operations.js)
-* [Service](examples/service_operations.js)
-* [StatefulSet](examples/statefulset_operations.js)
-
 ### Examples
 
 #### Creating a pod using a specification 


### PR DESCRIPTION
Since https://github.com/grafana/xk6-kubernetes/pull/85 all resources are supported.