### PR TITLE
Clarify Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,50 @@ export default function () {
 }
 ```
 
+#### Interacting with objects created by CRDs
+
+For objects outside of the core API, use the fully-qualified resource name.
+
+```javascript
+
+import { Kubernetes } from 'k6/x/kubernetes';
+
+const manifest = `
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: yaml-ingress
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - path: /my-service-path
+        pathType: Prefix
+        backend:
+          service:
+            name: my-service
+            port:
+              number: 80
+`
+
+export default function () {
+  const kubernetes = new Kubernetes();
+
+  kubernetes.apply(manifest);
+
+  const ingresses = kubernetes.list("Ingress.networking.k8s.io", "default")
+
+  console.log(`${ingresses.length} Ingress found:`);
+  ingresses.map(function(ingress) {
+    console.log(`  ${ingress.metadata.name}`)
+  });
+}
+
+
+```
+
 ## Helpers
 
 The `xk6-kubernetes` extension offers helpers to facilitate common tasks when setting up a tests. All helper functions work in a namespace to facilitate the development of tests segregated by namespace. The helpers are accessed using the following method:

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ Using the `k6` binary with `xk6-kubernetes`, run the k6 test as usual:
 
 By default, the API assumes a `kubeconfig` configuration is available at `$HOME/.kube`.
 
-You can pass in the following options as a javascript Object to the Kubernetes constructor:
+Alternatively, you can pass in the following options as a javascript Object to the Kubernetes constructor to configure access to the Kubernetes API server:
 
 | Option | Value | Description |
 | -- | --| ---- |
 | config_path | /path/to/kubeconfig | Kubeconfig file location. You can also set this to __ENV.KUBECONFIG to use the location pointed by the `KUBECONFIG` environment variable |
-| server | <SERVER_HOST> | Host for token login |
-| token | <TOKEN> | Token for token login |
+| server | <SERVER_HOST> | Kubernetes API server URL |
+| token | <TOKEN> | Bearer Token for authenticating to the Kubernetes API server |
 
 ```javascript
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,26 @@ Using the `k6` binary with `xk6-kubernetes`, run the k6 test as usual:
 ```
 # Usage
 
-The API assumes a `kubeconfig` configuration is available at any of the following default locations:
-* at the location pointed by the `KUBECONFIG` environment variable
-* at `$HOME/.kube`
+By default, the API assumes a `kubeconfig` configuration is available at `$HOME/.kube`.
 
+You can pass in the following options as a javascript Object to the Kubernetes constructor:
+
+| Option | Value | Description |
+| -- | --| ---- |
+| config_path | /path/to/kubeconfig | Kubeconfig file location. You can also set this to __ENV.KUBECONFIG to use the location pointed by the `KUBECONFIG` environment variable |
+| server | <SERVER_HOST> | Host for token login |
+| token | <TOKEN> | Token for token login |
+
+```javascript
+
+import { Kubernetes } from 'k6/x/kubernetes';
+
+export default function () {
+  const k = new Kubernetes({
+    config_map: '/path/to/kubeconfig',
+  });
+}
+```
 
 # APIs
 


### PR DESCRIPTION
## What

Readme updates 
* Edited the `Usage` section to include options that have been added to the Kubernetes constructor
* Added an example for interacting with CRDs, as noted in https://github.com/grafana/xk6-kubernetes/issues/86

## Why

I found some of the instructions incomplete and confusing, and I want to clarify them for future users.