### PR TITLE
Bump Go version to 1.25.8

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -48,7 +48,7 @@ jobs:
           echo "Version=$(head -n 1 "${GITHUB_WORKSPACE}/.golangci.yml" | tr -d '# ')" >> $GITHUB_OUTPUT
         id: version
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: ${{ steps.version.outputs.Version }}
           only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,8 @@
-# v1.64.8
+# v2.11.4
 # Please don't remove the first line. It is used in CI to determine the golangci version
+
+version: "2"
+
 run:
   timeout: 5m
 
@@ -9,59 +12,11 @@ issues:
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0
 
-  # We want to try and improve the comments in the k6 codebase, so individual
-  # non-golint items from the default exclusion list will gradually be added
-  # to the exclude-rules below
-  exclude-use-default: false
-
-  exclude-rules:
-    # Exclude duplicate code and function length and complexity checking in test
-    # files (due to common repeats and long functions in test code)
-    - path: _(test|gen)\.go
-      linters:
-        - cyclop
-        - dupl
-        - gocognit
-        - funlen
-        - lll
-    - linters:
-        - staticcheck
-      # Tracked in https://github.com/grafana/xk6-grpc/issues/14
-      text: "The entire proto file grpc/reflection/v1alpha/reflection.proto is marked as deprecated."
-    - linters:
-        - staticcheck
-      # tracked in https://github.com/grafana/xk6-kubernetes/issues/135
-      text: 'SA1019: corev1.EndpointSubset is deprecated'
-    - linters:
-        - staticcheck
-      # tracked in https://github.com/grafana/xk6-kubernetes/issues/135
-      text: 'SA1019: corev1.Endpoints is deprecated'
-
-    - linters:
-        - forbidigo
-      text: 'use of `os\.(SyscallError|Signal|Interrupt)` forbidden'
-
-linters-settings:
-  exhaustive:
-    default-signifies-exhaustive: true
-  cyclop:
-    max-complexity: 25
-  dupl:
-    threshold: 150
-  goconst:
-    min-len: 10
-    min-occurrences: 4
-  funlen:
-    lines: 80
-    statements: 60
-  forbidigo:
-    forbid:
-      - '^(fmt\\.Print(|f|ln)|print|println)$'
-      # Forbid everything in os, except os.Signal and os.SyscalError
-      - '^os\.(.*)$(# Using anything except Signal and SyscallError from the os package is forbidden )?'
-      # Forbid everything in syscall except the uppercase constants
-      - '^syscall\.[^A-Z_]+$(# Using anything except constants from the syscall package is forbidden )?'
-      - '^logrus\.Logger$'
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
 
 linters:
   disable-all: true
@@ -88,13 +43,9 @@ linters:
     - gocognit
     - goconst
     - gocritic
-    - gofmt
-    - gofumpt
-    - goimports
     - gomoddirectives
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - importas
     - ineffassign
@@ -118,7 +69,6 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - stylecheck
     - tparallel
     - typecheck
     - unconvert
@@ -128,4 +78,55 @@ linters:
     - usetesting
     - wastedassign
     - whitespace
-  fast: false
+
+  settings:
+    exhaustive:
+      default-signifies-exhaustive: true
+    cyclop:
+      max-complexity: 25
+    dupl:
+      threshold: 150
+    goconst:
+      min-len: 10
+      min-occurrences: 4
+    funlen:
+      lines: 80
+      statements: 60
+    forbidigo:
+      forbid:
+        - '^(fmt\\.Print(|f|ln)|print|println)$'
+        # Forbid everything in os, except os.Signal and os.SyscalError
+        - '^os\.(.*)$(# Using anything except Signal and SyscallError from the os package is forbidden )?'
+        # Forbid everything in syscall except the uppercase constants
+        - '^syscall\.[^A-Z_]+$(# Using anything except constants from the syscall package is forbidden )?'
+        - '^logrus\.Logger$'
+
+  exclusions:
+    # We want to try and improve the comments in the k6 codebase, so individual
+    # non-golint items from the default exclusion list will gradually be added
+    # to the rules below
+    rules:
+      # Exclude duplicate code and function length and complexity checking in test
+      # files (due to common repeats and long functions in test code)
+      - path: _(test|gen)\.go
+        linters:
+          - cyclop
+          - dupl
+          - gocognit
+          - funlen
+          - lll
+      - linters:
+          - staticcheck
+        # Tracked in https://github.com/grafana/xk6-grpc/issues/14
+        text: "The entire proto file grpc/reflection/v1alpha/reflection.proto is marked as deprecated."
+      - linters:
+          - staticcheck
+        # tracked in https://github.com/grafana/xk6-kubernetes/issues/135
+        text: 'SA1019: corev1.EndpointSubset is deprecated'
+      - linters:
+          - staticcheck
+        # tracked in https://github.com/grafana/xk6-kubernetes/issues/135
+        text: 'SA1019: corev1.Endpoints is deprecated'
+      - linters:
+          - forbidigo
+        text: 'use of `os\.(SyscallError|Signal|Interrupt)` forbidden'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,7 @@ formatters:
     - goimports
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - asasalint
     - asciicheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,7 +70,6 @@ linters:
     - sqlclosecheck
     - staticcheck
     - tparallel
-    - typecheck
     - unconvert
     - unparam
     - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,12 +94,12 @@ linters:
       statements: 60
     forbidigo:
       forbid:
-        - '^(fmt\\.Print(|f|ln)|print|println)$'
-        # Forbid everything in os, except os.Signal and os.SyscalError
-        - '^os\.(.*)$(# Using anything except Signal and SyscallError from the os package is forbidden )?'
-        # Forbid everything in syscall except the uppercase constants
-        - '^syscall\.[^A-Z_]+$(# Using anything except constants from the syscall package is forbidden )?'
-        - '^logrus\.Logger$'
+        - pattern: '^(fmt\.Print(|f|ln)|print|println)$'
+        - pattern: '^os\.(.*)$'
+          msg: "Using anything except Signal and SyscallError from the os package is forbidden"
+        - pattern: '^syscall\.[^A-Z_]+$'
+          msg: "Using anything except constants from the syscall package is forbidden"
+        - pattern: '^logrus\.Logger$'
 
   exclusions:
     # We want to try and improve the comments in the k6 codebase, so individual

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/xk6-kubernetes
 
-go 1.24.4
+go 1.25.8
 
 require (
 	go.k6.io/k6 v1.3.0


### PR DESCRIPTION
## What

Bumps the `go` directive in `go.mod` from `1.24.4` to `1.25.8`.

This also requires an upgrade to golangci from v1 to v2 due to the go version change.

## Why

The `build-with-xk6` CI job installs `xk6@latest`, which resolved to `v1.3.7`. This version requires Go >= 1.25.8, but the project was using Go 1.24.4. Because the workflow sets `GOTOOLCHAIN=local`, Go refuses to auto-upgrade and the job fails with:

```
go: go.k6.io/xk6/cmd/xk6@latest: go.k6.io/xk6@v1.3.7 requires go >= 1.25.8 (running go 1.24.4; GOTOOLCHAIN=local)
```

## Checklist

- [x] Tests pass locally
- [x] CI passes