### PR TITLE
chore: add toolchain to latest 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/grafana/xk6-kubernetes
 
-go 1.26.0
+go 1.25.0
+
+toolchain go1.25.11
 
 require (
 	go.k6.io/k6 v1.7.1

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/grafana/xk6-kubernetes
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.11
+toolchain go1.26.4
 
 require (
 	go.k6.io/k6 v1.7.1


### PR DESCRIPTION
## Summary
~Align `go.mod` to `go 1.25.0` and `toolchain go1.25.11` to match the k6-core baseline.~

Turns out k8s/api requires 1.26 so let at leasdt add a toolchain that fixes CVE warnings
## Test plan
- [ ] `go mod tidy` is clean
- [ ] CI passes