### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ import { Kubernetes } from 'k6/x/kubernetes';
 
 export default function () {
   const k = new Kubernetes({
-    config_map: '/path/to/kubeconfig',
+    config_path: '/path/to/kubeconfig',
   });
 }
 ```


### PR DESCRIPTION
This PR corrects `config_map` to `config_path` in README.